### PR TITLE
Parse confirmation descriptions

### DIFF
--- a/src/demos.rs
+++ b/src/demos.rs
@@ -10,24 +10,28 @@ pub fn demo_confirmation_menu() {
 			key: 12345,
 			conf_type: ConfirmationType::Trade,
 			creator: 09870987,
+			description: "example confirmation".into(),
 		},
 		Confirmation {
 			id: 1234,
 			key: 12345,
 			conf_type: ConfirmationType::MarketSell,
 			creator: 09870987,
+			description: "example confirmation".into(),
 		},
 		Confirmation {
 			id: 1234,
 			key: 12345,
 			conf_type: ConfirmationType::AccountRecovery,
 			creator: 09870987,
+			description: "example confirmation".into(),
 		},
 		Confirmation {
 			id: 1234,
 			key: 12345,
 			conf_type: ConfirmationType::Trade,
 			creator: 09870987,
+			description: "example confirmation".into(),
 		},
 	]);
 	println!("accept: {}, deny: {}", accept.len(), deny.len());

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -213,8 +213,14 @@ pub fn prompt_confirmation_menu(
 	}
 
 	return (
-		to_accept_idx.iter().map(|i| confirmations[*i]).collect(),
-		to_deny_idx.iter().map(|i| confirmations[*i]).collect(),
+		to_accept_idx
+			.iter()
+			.map(|i| confirmations[*i].clone())
+			.collect(),
+		to_deny_idx
+			.iter()
+			.map(|i| confirmations[*i].clone())
+			.collect(),
 	);
 }
 

--- a/steamguard/src/confirmation.rs
+++ b/steamguard/src/confirmation.rs
@@ -1,17 +1,18 @@
 /// A mobile confirmation. There are multiple things that can be confirmed, like trade offers.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Confirmation {
 	pub id: u64,
 	pub key: u64,
 	/// Trade offer ID or market transaction ID
 	pub creator: u64,
 	pub conf_type: ConfirmationType,
+	pub description: String,
 }
 
 impl Confirmation {
 	/// Human readable representation of this confirmation.
 	pub fn description(&self) -> String {
-		format!("{:?} id={} key={}", self.conf_type, self.id, self.key)
+		format!("{:?} - {}", self.conf_type, self.description)
 	}
 }
 

--- a/steamguard/src/lib.rs
+++ b/steamguard/src/lib.rs
@@ -394,4 +394,21 @@ mod tests {
 			}
 		);
 	}
+
+	#[test]
+	fn test_parse_phone_number_change() {
+		let text = include_str!("fixtures/confirmations/phone-number-change.html");
+		let confirmations = parse_confirmations(text.into()).unwrap();
+		assert_eq!(confirmations.len(), 1);
+		assert_eq!(
+			confirmations[0],
+			Confirmation {
+				id: 9931444017,
+				key: 9746021299562127894,
+				conf_type: ConfirmationType::AccountRecovery,
+				creator: 2861625242839108895,
+				description: "Account recovery Just now".into(),
+			}
+		);
+	}
 }


### PR DESCRIPTION
- parse descriptions for confirmations
- add test for account recovery confirmation

fixes #67
