### PR TITLE
forbid duplicates

### DIFF
--- a/src/accountmanager.rs
+++ b/src/accountmanager.rs
@@ -145,7 +145,10 @@ impl Manifest {
 		let file = File::open(path)?;
 		let reader = BufReader::new(file);
 		let account: SteamGuardAccount = serde_json::from_reader(reader)?;
-		ensure!(!self.account_exists(&account.account_name), "Account already exists in manifest, please remove it first.");
+		ensure!(
+			!self.account_exists(&account.account_name),
+			"Account already exists in manifest, please remove it first."
+		);
 		self.add_account(account);
 
 		return Ok(());

--- a/src/accountmanager.rs
+++ b/src/accountmanager.rs
@@ -116,6 +116,15 @@ impl Manifest {
 		Ok(())
 	}
 
+	pub fn account_exists(&self, account_name: &String) -> bool {
+		for entry in &self.entries {
+			if &entry.account_name == account_name {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	pub fn add_account(&mut self, account: SteamGuardAccount) {
 		debug!("adding account to manifest: {}", account.account_name);
 		let steamid = account.session.as_ref().map_or(0, |s| s.steam_id);
@@ -136,6 +145,7 @@ impl Manifest {
 		let file = File::open(path)?;
 		let reader = BufReader::new(file);
 		let account: SteamGuardAccount = serde_json::from_reader(reader)?;
+		ensure!(!self.account_exists(&account.account_name), "Account already exists in manifest, please remove it first.");
 		self.add_account(account);
 
 		return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -456,10 +456,16 @@ fn main() {
 							"Failed to remove authenticator from {}",
 							account.account_name
 						);
+						match tui::prompt_char("Would you like to remove it from the manifest anyway?", "yN") {
+							'y' => {
+								successful.push(account.account_name.clone());
+							}
+							_ => {}
+						}
 					}
 				}
 				Err(err) => {
-					println!(
+					error!(
 						"Unexpected error when removing authenticator from {}: {}",
 						account.account_name, err
 					);

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,9 +213,13 @@ fn main() {
 		print!("Username: ");
 		let username = tui::prompt();
 		if manifest.account_exists(&username) {
-			error!("Account {} already exists in manifest, remove it first", username);
+			error!(
+				"Account {} already exists in manifest, remove it first",
+				username
+			);
 		}
-		let session = do_login_raw(username).expect("Failed to log in. Account has not been linked.");
+		let session =
+			do_login_raw(username).expect("Failed to log in. Account has not been linked.");
 
 		let mut linker = AccountLinker::new(session);
 		let account: SteamGuardAccount;
@@ -461,7 +465,10 @@ fn main() {
 							"Failed to remove authenticator from {}",
 							account.account_name
 						);
-						match tui::prompt_char("Would you like to remove it from the manifest anyway?", "yN") {
+						match tui::prompt_char(
+							"Would you like to remove it from the manifest anyway?",
+							"yN",
+						) {
 							'y' => {
 								successful.push(account.account_name.clone());
 							}

--- a/src/main.rs
+++ b/src/main.rs
@@ -476,7 +476,10 @@ fn main() {
 		let server_time = steamapi::get_server_time();
 		debug!("Time used to generate codes: {}", server_time);
 		for account in selected_accounts {
-			info!("Generating code for {}", account.lock().unwrap().account_name);
+			info!(
+				"Generating code for {}",
+				account.lock().unwrap().account_name
+			);
 			trace!("{:?}", account);
 			let code = account.lock().unwrap().generate_code(server_time);
 			println!("{}", code);

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,7 +210,12 @@ fn main() {
 
 	if matches.is_present("setup") {
 		println!("Log in to the account that you want to link to steamguard-cli");
-		let session = do_login_raw().expect("Failed to log in. Account has not been linked.");
+		print!("Username: ");
+		let username = tui::prompt();
+		if manifest.account_exists(&username) {
+			error!("Account {} already exists in manifest, remove it first", username);
+		}
+		let session = do_login_raw(username).expect("Failed to log in. Account has not been linked.");
 
 		let mut linker = AccountLinker::new(session);
 		let account: SteamGuardAccount;
@@ -515,9 +520,7 @@ fn do_login(account: &mut SteamGuardAccount) -> anyhow::Result<()> {
 	return Ok(());
 }
 
-fn do_login_raw() -> anyhow::Result<steamapi::Session> {
-	print!("Username: ");
-	let username = tui::prompt();
+fn do_login_raw(username: String) -> anyhow::Result<steamapi::Session> {
 	let _ = std::io::stdout().flush();
 	let password = rpassword::prompt_password_stdout("Password: ").unwrap();
 	if password.len() > 0 {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -96,7 +96,7 @@ fn prompt_char_impl(input: &mut impl Read, text: &str, chars: &str) -> char {
 		}
 
 		let answer_char = answer.chars().collect::<Vec<char>>()[0];
-		if chars.contains(answer_char) {
+		if chars.to_ascii_lowercase().contains(answer_char) {
 			return answer_char;
 		}
 	}


### PR DESCRIPTION
- cargo fmt
- allow accounts to be removed from manifest without successfully removing authenticator from account
- don't allow setup or import for account_names already in the manifest, fixes #109
- fix small logic bug in prompt_char
