### PR TITLE
Better binary portability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,22 +261,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,21 +428,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -700,16 +669,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
- "bytes",
+ "http",
  "hyper",
- "native-tls",
+ "rustls",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -881,24 +850,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
-dependencies = [
- "lazy_static 1.4.0",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,51 +937,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl"
-version = "0.10.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
-dependencies = [
- "autocfg 1.1.0",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1178,12 +1084,6 @@ dependencies = [
  "spki",
  "zeroize",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "ppv-lite86"
@@ -1471,26 +1371,28 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "lazy_static 1.4.0",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "proc-macro-hack",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util 0.6.10",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -1558,6 +1460,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,16 +1497,6 @@ name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
-
-[[package]]
-name = "schannel"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
-dependencies = [
- "lazy_static 1.4.0",
- "windows-sys",
-]
 
 [[package]]
 name = "scopeguard"
@@ -1608,6 +1521,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,29 +1538,6 @@ checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
 dependencies = [
  "serde",
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2181,13 +2081,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
+name = "tokio-rustls"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "native-tls",
+ "rustls",
  "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -2332,12 +2233,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2466,6 +2361,25 @@ checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ hmac-sha1 = "^0.1"
 base64 = "0.13.0"
 text_io = "0.1.8"
 rpassword = "5.0"
-reqwest = { version = "0.11", features = ["blocking", "json", "cookies", "gzip"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "cookies", "gzip", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rsa = "0.5.0"

--- a/scripts/full-release.sh
+++ b/scripts/full-release.sh
@@ -81,17 +81,3 @@ if [[ $DRY_RUN == false ]]; then
   fi
 	gh release create "$VERSION" --title "$VERSION" --draft "$BIN_PATH" "./steamguard-cli_$RAW_VERSION-0.deb"
 fi
-
-# update PKGBUILD for AUR
-if [[ -d "aur" ]]; then
-	rm -rf aur
-fi
-git clone ssh://aur@aur.archlinux.org/steamguard-cli-git.git aur
-cp PKGBUILD aur/PKGBUILD
-cd aur
-git commit -m "release $VERSION" PKGBUILD
-if [[ $DRY_RUN == false ]]; then
-	git push
-	rm -rf aur
-fi
-cd ..

--- a/scripts/full-release.sh
+++ b/scripts/full-release.sh
@@ -58,11 +58,16 @@ if [[ $SKIP_CRATE_PUBLISH == true ]]; then
 fi
 cargo smart-release --update-crates-index --no-changelog "${params[@]}"
 
-cargo build --release
+if ! which cross; then
+	echo "cross not found, installing..."
+	cargo install cross
+fi
+
+cross build --release --target=x86_64-unknown-linux-musl
 
 ./scripts/package-deb.sh
 
-BIN_PATH="target/release/steamguard-cli"
+BIN_PATH="target/x86_64-unknown-linux-musl/release/steamguard-cli-x86_64-unknown-linux-musl"
 RAW_VERSION="$("$BIN_PATH" --version | cut -d " " -f 2)"
 TAGGED_VERSION="$(git tag | grep "^v" | tail -n 1 | tr -d v)"
 if [[ "v$RAW_VERSION" != "v$TAGGED_VERSION" ]]; then

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -5,10 +5,15 @@ set -e
 DISTRO=$(lsb_release -i -s)
 DISTRO_VERSION=$(lsb_release -r -s)
 
-BIN_PATH="target/release/steamguard-cli"
+if ! which cross; then
+	echo "cross not found, installing..."
+	cargo install cross
+fi
+
+BIN_PATH="target/x86_64-unknown-linux-musl/release/steamguard-cli"
 if [[ ! -f "$BIN_PATH" ]]; then
 	echo "ERROR: Could not find release binaries, building them..."
-	cargo build --release
+	cross build --release --target=x86_64-unknown-linux-musl
 fi
 VERSION="$("$BIN_PATH" --version | cut -d " " -f 2)"
 TEMP_PKG_PATH="/tmp/steamguard-cli_$VERSION"

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -24,6 +24,9 @@ mkdir -p "$TEMP_PKG_PATH/etc/bash_completion.d"
 mkdir -p "$TEMP_PKG_PATH/DEBIAN"
 
 cp "$BIN_PATH" "$TEMP_PKG_PATH/usr/local/bin/steamguard"
+pushd "$TEMP_PKG_PATH/usr/local/bin/"
+ln -s "./steamguard" "./steamguard-cli"
+popd
 "$BIN_PATH" completion --shell bash > "$TEMP_PKG_PATH/etc/bash_completion.d/steamguard"
 
 cat <<EOT >> $TEMP_PKG_PATH/DEBIAN/control

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -2,14 +2,17 @@
 
 set -e
 
+DISTRO=$(lsb_release -i -s)
+DISTRO_VERSION=$(lsb_release -r -s)
+
 BIN_PATH="target/release/steamguard-cli"
 if [[ ! -f "$BIN_PATH" ]]; then
 	echo "ERROR: Could not find release binaries, building them..."
 	cargo build --release
 fi
-VERSION="$("$BIN_PATH" --version | cut -d " " -f 2)-0"
+VERSION="$("$BIN_PATH" --version | cut -d " " -f 2)"
 TEMP_PKG_PATH="/tmp/steamguard-cli_$VERSION"
-echo "Building Debian package for v$VERSION..."
+echo "Building package on $DISTRO $DISTRO_VERSION for v$VERSION..."
 
 mkdir -p "$TEMP_PKG_PATH/usr/local/bin"
 mkdir -p "$TEMP_PKG_PATH/etc/bash_completion.d"
@@ -30,6 +33,6 @@ Description: steamguard-cli
  A command line utility to generate Steam 2FA codes and respond to confirmations.
 EOT
 
-dpkg-deb --build "$TEMP_PKG_PATH" "steamguard-cli_$VERSION.deb"
+dpkg-deb --build "$TEMP_PKG_PATH" "steamguard-cli_$VERSION-0.deb"
 
 rm -rf "$TEMP_PKG_PATH"

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -35,7 +35,7 @@ Depends:
 Version: $VERSION
 Section: base
 Priority: optional
-Architecture: all
+Architecture: x86_64
 Maintainer: Carson McManus <carson.mcmanus1@gmail.com>
 Description: steamguard-cli
  A command line utility to generate Steam 2FA codes and respond to confirmations.

--- a/steamguard/Cargo.toml
+++ b/steamguard/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 anyhow = "^1.0"
 hmac-sha1 = "^0.1"
 base64 = "0.13.0"
-reqwest = { version = "0.11", features = ["blocking", "json", "cookies", "gzip"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "cookies", "gzip", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rsa = "0.5.0"


### PR DESCRIPTION
- log distro info when building deb
- switch to using rustls-tls to make binaries more portable
- build releases using cross for more portable builds
- add symlink for "steamguard-cli" in deb packages
- fix deb package architecture metadata
- remove aur updater from full release script
