### PR TITLE
Upgrade to clap v3, switch argument parsing to derive api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,26 +183,35 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static 1.4.0",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
 ]
 
 [[package]]
-name = "clap_derive"
-version = "3.1.18"
+name = "clap_complete"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "0f6ebaab5f25e4f0312dfa07cb30a755204b96e6531457c2cfdecfdf5f2adf40"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11d40217d16aee8508cc8e5fde8b4ff24639758608e5374e731b53f85749fb9"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -213,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1859,6 +1868,7 @@ dependencies = [
  "base64",
  "block-modes",
  "clap",
+ "clap_complete",
  "cookie 0.14.4",
  "dirs",
  "hmac-sha1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,15 +30,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,17 +183,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static 1.4.0",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -579,6 +594,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,6 +960,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1123,30 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -1860,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -1957,12 +2008,9 @@ checksum = "442f2674e6bd8489052b958e0eaebd89c26eefa3be9dc359d1e2ecccdc510f45"
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thin-slice"
@@ -2231,12 +2279,6 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.6",
 ]
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 [package]
 name = "steamguard-cli"
 version = "0.4.5"
-authors = ["Carson McManus <carson.mcmanus1@gmail.com>"]
+authors = ["dyc3 (Carson McManus) <carson.mcmanus1@gmail.com>"]
 edition = "2018"
 description = "A command line utility to generate Steam 2FA codes and respond to confirmations."
 keywords = ["steam", "2fa", "steamguard", "authentication", "cli"]
@@ -33,7 +33,7 @@ serde_json = "1.0"
 rsa = "0.5.0"
 rand = "0.8.4"
 standback = "0.2.17" # required to fix a compilation error on a transient dependency
-clap = "2.33.3"
+clap = { version = "3.1.18", features = ["derive", "cargo"] }
 log = "0.4.14"
 stderrlog = "0.4"
 cookie = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rsa = "0.5.0"
 rand = "0.8.4"
 standback = "0.2.17" # required to fix a compilation error on a transient dependency
 clap = { version = "3.1.18", features = ["derive", "cargo"] }
+clap_complete = "3.2.1"
 log = "0.4.14"
 stderrlog = "0.4"
 cookie = "0.14"

--- a/src/accountmanager.rs
+++ b/src/accountmanager.rs
@@ -180,8 +180,8 @@ impl Manifest {
 			.insert(account.account_name.clone(), Arc::new(Mutex::new(account)));
 	}
 
-	pub fn import_account(&mut self, import_path: String) -> anyhow::Result<()> {
-		let path = Path::new(&import_path);
+	pub fn import_account(&mut self, import_path: &String) -> anyhow::Result<()> {
+		let path = Path::new(import_path);
 		ensure!(path.exists(), "{} does not exist.", import_path);
 		ensure!(path.is_file(), "{} is not a file.", import_path);
 
@@ -576,7 +576,7 @@ mod tests {
 		let mut loaded_manifest = Manifest::new(manifest_path.as_path());
 		assert!(matches!(
 			loaded_manifest.import_account(
-				tmp_dir
+				&tmp_dir
 					.path()
 					.join("asdf1234.maFile")
 					.into_os_string()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use std::str::FromStr;
 use clap::Parser;
+use clap_complete::Shell;
 
 #[derive(Debug, Clone, Parser)]
 #[clap(author, version, about = "Generate Steam 2FA codes and confirm Steam trades from the command line.", long_about = None)]
@@ -23,9 +24,7 @@ pub(crate) struct Args {
 #[derive(Debug, Clone, Parser)]
 pub(crate) enum Subcommands {
 	Debug(ArgsDebug),
-	// Completions {
-		// TODO: Add completions
-	// },
+	Completion(ArgsCompletions),
 	Setup(ArgsSetup),
 	Import(ArgsImport),
 	Trade(ArgsTrade),
@@ -76,6 +75,13 @@ impl FromStr for Verbosity {
 pub(crate) struct ArgsDebug {
 	#[clap(long, help = "Show an example confirmation menu using dummy data.")]
 	pub demo_conf_menu: bool
+}
+
+#[derive(Debug, Clone, Parser)]
+#[clap(about="Generate shell completions")]
+pub(crate) struct ArgsCompletions {
+	#[clap(arg_enum, help = "The shell to generate completions for.")]
+	pub shell: Shell,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,7 +74,7 @@ impl FromStr for Verbosity {
 #[derive(Debug, Clone, Parser)]
 #[clap(about="Debug stuff, not useful for most users.")]
 pub(crate) struct ArgsDebug {
-	#[clap(long)]
+	#[clap(long, help = "Show an example confirmation menu using dummy data.")]
 	pub demo_conf_menu: bool
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,39 +22,16 @@ pub(crate) struct Args {
 
 #[derive(Debug, Clone, Parser)]
 pub(crate) enum Subcommands {
-	Debug {
-		#[clap(long)]
-		demo_conf_menu: bool
-	},
+	Debug(ArgsDebug),
 	// Completions {
 		// TODO: Add completions
 	// },
-	#[clap(about = "Interactive interface for trade confirmations")]
-	Trade {
-		#[clap(short, long, help = "Accept all open trade confirmations. Does not open interactive interface.")]
-		accept_all: bool,
-		#[clap(short, long, help = "If submitting a confirmation response fails, exit immediately.")]
-		fail_fast: bool,
-	},
-	#[clap(about = "Set up a new account with steamguard-cli")]
-	Setup {
-		#[clap(short, long, from_global, help = "Steam username, case-sensitive.")]
-		username: Option<String>,
-	},
-	#[clap(about = "Import an account with steamguard already set up")]
-	Import {
-		#[clap(long, help = "Paths to one or more maFiles, eg. \"./gaben.maFile\"")]
-		files: Vec<String>,
-	},
-	#[clap(about = "Remove the authenticator from an account.")]
-	Remove {
-		#[clap(short, long, from_global, help = "Steam username, case-sensitive.")]
-		username: String,
-	},
-	#[clap(about = "Encrypt all maFiles")]
-	Encrypt,
-	#[clap(about = "Decrypt all maFiles")]
-	Decrypt,
+	Setup(ArgsSetup),
+	Import(ArgsImport),
+	Trade(ArgsTrade),
+	Remove(ArgsRemove),
+	Encrypt(ArgsEncrypt),
+	Decrypt(ArgsDecrypt),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -93,42 +70,48 @@ impl FromStr for Verbosity {
 	}
 }
 
+
+#[derive(Debug, Clone, Parser)]
+#[clap(about="Debug stuff, not useful for most users.")]
+pub(crate) struct ArgsDebug {
+	#[clap(long)]
+	pub demo_conf_menu: bool
+}
+
+#[derive(Debug, Clone, Parser)]
+#[clap(about = "Set up a new account with steamguard-cli")]
 pub(crate) struct ArgsSetup {
+	#[clap(short, long, from_global, help = "Steam username, case-sensitive.")]
 	pub username: Option<String>,
 }
 
-impl From<Subcommands> for ArgsSetup {
-	fn from(sub: Subcommands) -> Self {
-		match sub {
-			Subcommands::Setup { username } => Self { username },
-			_ => panic!("ArgsSetup::from() called with non-Setup subcommand"),
-		}
-	}
-}
-
+#[derive(Debug, Clone, Parser)]
+#[clap(about = "Import an account with steamguard already set up")]
 pub(crate) struct ArgsImport {
+	#[clap(long, help = "Paths to one or more maFiles, eg. \"./gaben.maFile\"")]
 	pub files: Vec<String>,
 }
 
-impl From<Subcommands> for ArgsImport {
-	fn from(sub: Subcommands) -> Self {
-		match sub {
-			Subcommands::Import { files } => Self { files },
-			_ => panic!("ArgsImport::from() called with non-Import subcommand"),
-		}
-	}
-}
-
+#[derive(Debug, Clone, Parser)]
+#[clap(about = "Interactive interface for trade confirmations")]
 pub(crate) struct ArgsTrade {
+	#[clap(short, long, help = "Accept all open trade confirmations. Does not open interactive interface.")]
 	pub accept_all: bool,
+	#[clap(short, long, help = "If submitting a confirmation response fails, exit immediately.")]
 	pub fail_fast: bool,
 }
 
-impl From<Subcommands> for ArgsTrade {
-	fn from(sub: Subcommands) -> Self {
-		match sub {
-			Subcommands::Trade { accept_all, fail_fast } => Self { accept_all, fail_fast },
-			_ => panic!("ArgsTrade::from() called with non-Trade subcommand"),
-		}
-	}
+#[derive(Debug, Clone, Parser)]
+#[clap(about = "Remove the authenticator from an account.")]
+pub(crate) struct ArgsRemove {
+	#[clap(short, long, from_global, help = "Steam username, case-sensitive.")]
+	username: String,
 }
+
+#[derive(Debug, Clone, Parser)]
+#[clap(about = "Encrypt all maFiles")]
+pub(crate) struct ArgsEncrypt;
+
+#[derive(Debug, Clone, Parser)]
+#[clap(about = "Decrypt all maFiles")]
+pub(crate) struct ArgsDecrypt;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,16 +1,31 @@
-use std::str::FromStr;
-use clap::{Parser, clap_derive::ArgEnum};
+use clap::{clap_derive::ArgEnum, Parser};
 use clap_complete::Shell;
+use std::str::FromStr;
 
 #[derive(Debug, Clone, Parser)]
 #[clap(name="steamguard-cli", bin_name="steamguard", author, version, about = "Generate Steam 2FA codes and confirm Steam trades from the command line.", long_about = None)]
 pub(crate) struct Args {
-	#[clap(short, long, conflicts_with="all", help = "Steam username, case-sensitive.", long_help = "Select the account you want by steam username. Case-sensitive. By default, the first account in the manifest is selected.")]
+	#[clap(
+		short,
+		long,
+		conflicts_with = "all",
+		help = "Steam username, case-sensitive.",
+		long_help = "Select the account you want by steam username. Case-sensitive. By default, the first account in the manifest is selected."
+	)]
 	pub username: Option<String>,
-	#[clap(short, long, conflicts_with="username", help = "Select all accounts in the manifest.")]
+	#[clap(
+		short,
+		long,
+		conflicts_with = "username",
+		help = "Select all accounts in the manifest."
+	)]
 	pub all: bool,
 	/// The path to the maFiles directory.
-	#[clap(short, long, help = "Specify which folder your maFiles are in. This should be a path to a folder that contains manifest.json. Default: ~/.config/steamguard-cli/maFiles")]
+	#[clap(
+		short,
+		long,
+		help = "Specify which folder your maFiles are in. This should be a path to a folder that contains manifest.json. Default: ~/.config/steamguard-cli/maFiles"
+	)]
 	pub mafiles_path: Option<String>,
 	#[clap(short, long, help = "Specify your encryption passkey.")]
 	pub passkey: Option<String>,
@@ -44,13 +59,16 @@ pub(crate) enum Verbosity {
 
 impl std::fmt::Display for Verbosity {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		f.write_fmt(format_args!("{}", match self {
-			Verbosity::Error => "error",
-			Verbosity::Warn => "warn",
-			Verbosity::Info => "info",
-			Verbosity::Debug => "debug",
-			Verbosity::Trace => "trace",
-		}))
+		f.write_fmt(format_args!(
+			"{}",
+			match self {
+				Verbosity::Error => "error",
+				Verbosity::Warn => "warn",
+				Verbosity::Info => "info",
+				Verbosity::Debug => "debug",
+				Verbosity::Trace => "trace",
+			}
+		))
 	}
 }
 
@@ -69,16 +87,15 @@ impl FromStr for Verbosity {
 	}
 }
 
-
 #[derive(Debug, Clone, Parser)]
-#[clap(about="Debug stuff, not useful for most users.")]
+#[clap(about = "Debug stuff, not useful for most users.")]
 pub(crate) struct ArgsDebug {
 	#[clap(long, help = "Show an example confirmation menu using dummy data.")]
-	pub demo_conf_menu: bool
+	pub demo_conf_menu: bool,
 }
 
 #[derive(Debug, Clone, Parser)]
-#[clap(about="Generate shell completions")]
+#[clap(about = "Generate shell completions")]
 pub(crate) struct ArgsCompletions {
 	#[clap(short, long, arg_enum, help = "The shell to generate completions for.")]
 	pub shell: Shell,
@@ -101,9 +118,17 @@ pub(crate) struct ArgsImport {
 #[derive(Debug, Clone, Parser)]
 #[clap(about = "Interactive interface for trade confirmations")]
 pub(crate) struct ArgsTrade {
-	#[clap(short, long, help = "Accept all open trade confirmations. Does not open interactive interface.")]
+	#[clap(
+		short,
+		long,
+		help = "Accept all open trade confirmations. Does not open interactive interface."
+	)]
 	pub accept_all: bool,
-	#[clap(short, long, help = "If submitting a confirmation response fails, exit immediately.")]
+	#[clap(
+		short,
+		long,
+		help = "If submitting a confirmation response fails, exit immediately."
+	)]
 	pub fail_fast: bool,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use clap_complete::Shell;
 
 #[derive(Debug, Clone, Parser)]
-#[clap(author, version, about = "Generate Steam 2FA codes and confirm Steam trades from the command line.", long_about = None)]
+#[clap(name="steamguard-cli", bin_name="steamguard", author, version, about = "Generate Steam 2FA codes and confirm Steam trades from the command line.", long_about = None)]
 pub(crate) struct Args {
 	#[clap(short, long, help = "Steam username, case-sensitive.", long_help = "Select the account you want by steam username. Case-sensitive. By default, the first account in the manifest is selected.")]
 	pub username: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use clap::Parser;
+use clap::{Parser, clap_derive::ArgEnum};
 use clap_complete::Shell;
 
 #[derive(Debug, Clone, Parser)]
@@ -14,7 +14,7 @@ pub(crate) struct Args {
 	pub mafiles_path: Option<String>,
 	#[clap(short, long, help = "Specify your encryption passkey.")]
 	pub passkey: Option<String>,
-	#[clap(short, long, default_value_t=Verbosity::Info, help = "Set the log level.")]
+	#[clap(short, long, arg_enum, default_value_t=Verbosity::Info, help = "Set the log level.")]
 	pub verbosity: Verbosity,
 
 	#[clap(subcommand)]
@@ -33,7 +33,7 @@ pub(crate) enum Subcommands {
 	Decrypt(ArgsDecrypt),
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, ArgEnum)]
 pub(crate) enum Verbosity {
 	Error = 0,
 	Warn = 1,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,134 @@
+use std::str::FromStr;
+use clap::Parser;
+
+#[derive(Debug, Clone, Parser)]
+#[clap(author, version, about = "Generate Steam 2FA codes and confirm Steam trades from the command line.", long_about = None)]
+pub(crate) struct Args {
+	#[clap(short, long, help = "Steam username, case-sensitive.", long_help = "Select the account you want by steam username. Case-sensitive. By default, the first account in the manifest is selected.")]
+	pub username: Option<String>,
+	#[clap(short, long, help = "Select all accounts in the manifest.")]
+	pub all: bool,
+	/// The path to the maFiles directory.
+	#[clap(short, long, default_value = "~/.config/steamguard-cli/maFiles", help = "Specify which folder your maFiles are in. This should be a path to a folder that contains manifest.json.")]
+	pub mafiles_path: String,
+	#[clap(short, long, help = "Specify your encryption passkey.")]
+	pub passkey: Option<String>,
+	#[clap(short, long, default_value_t=Verbosity::Info, help = "Set the log level.")]
+	pub verbosity: Verbosity,
+
+	#[clap(subcommand)]
+	pub sub: Option<Subcommands>,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub(crate) enum Subcommands {
+	Debug {
+		#[clap(long)]
+		demo_conf_menu: bool
+	},
+	// Completions {
+		// TODO: Add completions
+	// },
+	#[clap(about = "Interactive interface for trade confirmations")]
+	Trade {
+		#[clap(short, long, help = "Accept all open trade confirmations. Does not open interactive interface.")]
+		accept_all: bool,
+		#[clap(short, long, help = "If submitting a confirmation response fails, exit immediately.")]
+		fail_fast: bool,
+	},
+	#[clap(about = "Set up a new account with steamguard-cli")]
+	Setup {
+		#[clap(short, long, from_global, help = "Steam username, case-sensitive.")]
+		username: Option<String>,
+	},
+	#[clap(about = "Import an account with steamguard already set up")]
+	Import {
+		#[clap(long, help = "Paths to one or more maFiles, eg. \"./gaben.maFile\"")]
+		files: Vec<String>,
+	},
+	#[clap(about = "Remove the authenticator from an account.")]
+	Remove {
+		#[clap(short, long, from_global, help = "Steam username, case-sensitive.")]
+		username: String,
+	},
+	#[clap(about = "Encrypt all maFiles")]
+	Encrypt,
+	#[clap(about = "Decrypt all maFiles")]
+	Decrypt,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Verbosity {
+	Error = 0,
+	Warn = 1,
+	Info = 2,
+	Debug = 3,
+	Trace = 4,
+}
+
+impl std::fmt::Display for Verbosity {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.write_fmt(format_args!("{}", match self {
+			Verbosity::Error => "error",
+			Verbosity::Warn => "warn",
+			Verbosity::Info => "info",
+			Verbosity::Debug => "debug",
+			Verbosity::Trace => "trace",
+		}))
+	}
+}
+
+impl FromStr for Verbosity {
+	type Err = anyhow::Error;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		match s {
+			"error" => Ok(Verbosity::Error),
+			"warn" => Ok(Verbosity::Warn),
+			"info" => Ok(Verbosity::Info),
+			"debug" => Ok(Verbosity::Debug),
+			"trace" => Ok(Verbosity::Trace),
+			_ => Err(anyhow!("Invalid verbosity level: {}", s)),
+		}
+	}
+}
+
+pub(crate) struct ArgsSetup {
+	pub username: Option<String>,
+}
+
+impl From<Subcommands> for ArgsSetup {
+	fn from(sub: Subcommands) -> Self {
+		match sub {
+			Subcommands::Setup { username } => Self { username },
+			_ => panic!("ArgsSetup::from() called with non-Setup subcommand"),
+		}
+	}
+}
+
+pub(crate) struct ArgsImport {
+	pub files: Vec<String>,
+}
+
+impl From<Subcommands> for ArgsImport {
+	fn from(sub: Subcommands) -> Self {
+		match sub {
+			Subcommands::Import { files } => Self { files },
+			_ => panic!("ArgsImport::from() called with non-Import subcommand"),
+		}
+	}
+}
+
+pub(crate) struct ArgsTrade {
+	pub accept_all: bool,
+	pub fail_fast: bool,
+}
+
+impl From<Subcommands> for ArgsTrade {
+	fn from(sub: Subcommands) -> Self {
+		match sub {
+			Subcommands::Trade { accept_all, fail_fast } => Self { accept_all, fail_fast },
+			_ => panic!("ArgsTrade::from() called with non-Trade subcommand"),
+		}
+	}
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,10 +103,7 @@ pub(crate) struct ArgsTrade {
 
 #[derive(Debug, Clone, Parser)]
 #[clap(about = "Remove the authenticator from an account.")]
-pub(crate) struct ArgsRemove {
-	#[clap(short, long, from_global, help = "Steam username, case-sensitive.")]
-	username: String,
-}
+pub(crate) struct ArgsRemove;
 
 #[derive(Debug, Clone, Parser)]
 #[clap(about = "Encrypt all maFiles")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,8 +9,8 @@ pub(crate) struct Args {
 	#[clap(short, long, help = "Select all accounts in the manifest.")]
 	pub all: bool,
 	/// The path to the maFiles directory.
-	#[clap(short, long, default_value = "~/.config/steamguard-cli/maFiles", help = "Specify which folder your maFiles are in. This should be a path to a folder that contains manifest.json.")]
-	pub mafiles_path: String,
+	#[clap(short, long, help = "Specify which folder your maFiles are in. This should be a path to a folder that contains manifest.json. Default: ~/.config/steamguard-cli/maFiles")]
+	pub mafiles_path: Option<String>,
 	#[clap(short, long, help = "Specify your encryption passkey.")]
 	pub passkey: Option<String>,
 	#[clap(short, long, default_value_t=Verbosity::Info, help = "Set the log level.")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,7 +80,7 @@ pub(crate) struct ArgsDebug {
 #[derive(Debug, Clone, Parser)]
 #[clap(about="Generate shell completions")]
 pub(crate) struct ArgsCompletions {
-	#[clap(arg_enum, help = "The shell to generate completions for.")]
+	#[clap(short, long, arg_enum, help = "The shell to generate completions for.")]
 	pub shell: Shell,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,9 +5,9 @@ use clap_complete::Shell;
 #[derive(Debug, Clone, Parser)]
 #[clap(name="steamguard-cli", bin_name="steamguard", author, version, about = "Generate Steam 2FA codes and confirm Steam trades from the command line.", long_about = None)]
 pub(crate) struct Args {
-	#[clap(short, long, help = "Steam username, case-sensitive.", long_help = "Select the account you want by steam username. Case-sensitive. By default, the first account in the manifest is selected.")]
+	#[clap(short, long, conflicts_with="all", help = "Steam username, case-sensitive.", long_help = "Select the account you want by steam username. Case-sensitive. By default, the first account in the manifest is selected.")]
 	pub username: Option<String>,
-	#[clap(short, long, help = "Select all accounts in the manifest.")]
+	#[clap(short, long, conflicts_with="username", help = "Select all accounts in the manifest.")]
 	pub all: bool,
 	/// The path to the maFiles directory.
 	#[clap(short, long, help = "Specify which folder your maFiles are in. This should be a path to a folder that contains manifest.json. Default: ~/.config/steamguard-cli/maFiles")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ pub(crate) struct Args {
 	pub mafiles_path: Option<String>,
 	#[clap(short, long, help = "Specify your encryption passkey.")]
 	pub passkey: Option<String>,
-	#[clap(short, long, arg_enum, default_value_t=Verbosity::Info, help = "Set the log level.")]
+	#[clap(short, long, arg_enum, default_value_t=Verbosity::Info, help = "Set the log level. Be warned, trace is capable of printing sensitive data.")]
 	pub verbosity: Verbosity,
 
 	#[clap(subcommand)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,4 +4,6 @@ use thiserror::Error;
 pub(crate) enum UserError {
 	#[error("User aborted the operation.")]
 	Aborted,
+	#[error("Unknown subcommand. It may need to be implemented.")]
+	UnknownSubcommand,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use steamguard::{
 	SteamGuardAccount, UserLogin,
 };
 
-use crate::accountmanager::ManifestAccountLoadError;
+use crate::{accountmanager::ManifestAccountLoadError, cli::Subcommands};
 
 #[macro_use]
 extern crate lazy_static;
@@ -157,8 +157,8 @@ fn run() -> anyhow::Result<()> {
 		.unwrap();
 
 	match new_args.sub {
-		Some(cli::Subcommands::Debug{demo_conf_menu}) => {
-			if demo_conf_menu {
+		Some(cli::Subcommands::Debug(args)) => {
+			if args.demo_conf_menu {
 				demos::demo_confirmation_menu();
 			}
 			return Ok(());
@@ -233,13 +233,13 @@ fn run() -> anyhow::Result<()> {
 		}
 	}
 
-	match &new_args.sub {
-		Some(cli::Subcommands::Setup{ username }) => {
-			return do_subcmd_setup(new_args.sub.unwrap().into(), &mut manifest);
+	match new_args.sub {
+		Some(cli::Subcommands::Setup(args)) => {
+			return do_subcmd_setup(args, &mut manifest);
 		},
-		Some(cli::Subcommands::Import { files }) => {todo!()},
-		Some(cli::Subcommands::Encrypt {}) => {todo!()},
-		Some(cli::Subcommands::Decrypt {}) => {todo!()},
+		Some(cli::Subcommands::Import(args)) => {todo!()},
+		Some(cli::Subcommands::Encrypt(args)) => {todo!()},
+		Some(cli::Subcommands::Decrypt(args)) => {todo!()},
 		_ => {},
 	}
 
@@ -321,7 +321,7 @@ fn run() -> anyhow::Result<()> {
 	);
 
 	match new_args.sub.as_ref() {
-		Some(cli::Subcommands::Trade{ accept_all, fail_fast }) => {
+		Some(cli::Subcommands::Trade(args)) => {
 			for a in selected_accounts.iter_mut() {
 				let mut account = a.lock().unwrap();
 
@@ -341,14 +341,14 @@ fn run() -> anyhow::Result<()> {
 				}
 
 				let mut any_failed = false;
-				if *accept_all {
+				if args.accept_all {
 					info!("accepting all confirmations");
 					for conf in &confirmations {
 						let result = account.accept_confirmation(conf);
 						if result.is_err() {
 							warn!("accept confirmation result: {:?}", result);
 							any_failed = true;
-							if *fail_fast {
+							if args.fail_fast {
 								return result;
 							}
 						} else {
@@ -363,7 +363,7 @@ fn run() -> anyhow::Result<()> {
 							if result.is_err() {
 								warn!("accept confirmation result: {:?}", result);
 								any_failed = true;
-								if *fail_fast {
+								if args.fail_fast {
 									return result;
 								}
 							} else {
@@ -376,7 +376,7 @@ fn run() -> anyhow::Result<()> {
 							if result.is_err() {
 								warn!("deny confirmation result: {:?}", result);
 								any_failed = true;
-								if *fail_fast {
+								if args.fail_fast {
 									return result;
 								}
 							} else {
@@ -398,7 +398,7 @@ fn run() -> anyhow::Result<()> {
 
 			manifest.save()?;
 		},
-		Some(cli::Subcommands::Remove { username }) => {
+		Some(cli::Subcommands::Remove(args)) => {
 			println!(
 				"This will remove the mobile authenticator from {} accounts: {}",
 				selected_accounts.len(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use steamguard::{
 	SteamGuardAccount, UserLogin,
 };
 
-use crate::{accountmanager::ManifestAccountLoadError};
+use crate::accountmanager::ManifestAccountLoadError;
 
 #[macro_use]
 extern crate lazy_static;
@@ -135,7 +135,7 @@ fn run() -> anyhow::Result<()> {
 		_ => {},
 	}
 
-	let mut selected_accounts: Vec<Arc<Mutex<SteamGuardAccount>>>;
+	let selected_accounts: Vec<Arc<Mutex<SteamGuardAccount>>>;
 	loop {
 		match get_selected_accounts(&args, &mut manifest) {
 			Ok(accounts) => {
@@ -529,7 +529,7 @@ fn do_subcmd_trade(args: cli::ArgsTrade, manifest: &mut accountmanager::Manifest
 	return Ok(());
 }
 
-fn do_subcmd_remove(args: cli::ArgsRemove, manifest: &mut accountmanager::Manifest, selected_accounts: Vec<Arc<Mutex<SteamGuardAccount>>>) -> anyhow::Result<()> {
+fn do_subcmd_remove(_args: cli::ArgsRemove, manifest: &mut accountmanager::Manifest, selected_accounts: Vec<Arc<Mutex<SteamGuardAccount>>>) -> anyhow::Result<()> {
 	println!(
 		"This will remove the mobile authenticator from {} accounts: {}",
 		selected_accounts.len(),
@@ -589,7 +589,7 @@ fn do_subcmd_remove(args: cli::ArgsRemove, manifest: &mut accountmanager::Manife
 	return Ok(());
 }
 
-fn do_subcmd_encrypt(args: cli::ArgsEncrypt, manifest: &mut accountmanager::Manifest) -> anyhow::Result<()> {
+fn do_subcmd_encrypt(_args: cli::ArgsEncrypt, manifest: &mut accountmanager::Manifest) -> anyhow::Result<()> {
 	if !manifest.has_passkey() {
 		let mut passkey;
 		loop {
@@ -611,7 +611,7 @@ fn do_subcmd_encrypt(args: cli::ArgsEncrypt, manifest: &mut accountmanager::Mani
 	return Ok(());
 }
 
-fn do_subcmd_decrypt(args: cli::ArgsDecrypt, manifest: &mut accountmanager::Manifest) -> anyhow::Result<()> {
+fn do_subcmd_decrypt(_args: cli::ArgsDecrypt, manifest: &mut accountmanager::Manifest) -> anyhow::Result<()> {
 	manifest.load_accounts()?;
 	for entry in &mut manifest.entries {
 		entry.encryption = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ mod errors;
 mod tui;
 
 #[derive(Debug, Clone, Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about = "Generate Steam 2FA codes and confirm Steam trades from the command line.", long_about = None)]
 struct Args {
 	#[clap(short, long, help = "Steam username, case-sensitive.", long_help = "Select the account you want by steam username. Case-sensitive. By default, the first account in the manifest is selected.")]
 	username: Option<String>,
@@ -43,6 +43,46 @@ struct Args {
 	passkey: Option<String>,
 	#[clap(short, long, default_value_t=Verbosity::Info, help = "Set the log level.")]
 	verbosity: Verbosity,
+
+	#[clap(subcommand)]
+	sub: Subcommands,
+}
+
+#[derive(Debug, Clone, Parser)]
+enum Subcommands {
+	Debug {
+		#[clap(long)]
+		demo_conf_menu: bool
+	},
+	// Completions {
+		// TODO: Add completions
+	// },
+	#[clap(about = "Interactive interface for trade confirmations")]
+	Trade {
+		#[clap(short, long, help = "Accept all open trade confirmations. Does not open interactive interface.")]
+		accept_all: bool,
+		#[clap(short, long, help = "If submitting a confirmation response fails, exit immediately.")]
+		fail_fast: bool,
+	},
+	#[clap(about = "Set up a new account with steamguard-cli")]
+	Setup {
+		#[clap(short, long, from_global, help = "Steam username, case-sensitive.")]
+		username: String,
+	},
+	#[clap(about = "Import an account with steamguard already set up")]
+	Import {
+		#[clap(long, help = "Paths to one or more maFiles, eg. \"./gaben.maFile\"")]
+		files: Vec<String>,
+	},
+	#[clap(about = "Remove the authenticator from an account.")]
+	Remove {
+		#[clap(short, long, from_global, help = "Steam username, case-sensitive.")]
+		username: String,
+	},
+	#[clap(about = "Encrypt all maFiles")]
+	Encrypt,
+	#[clap(about = "Decrypt all maFiles")]
+	Decrypt,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,8 +157,8 @@ fn run() -> anyhow::Result<()> {
 		_ => {},
 	};
 
-	let mafiles_dir = if let Some(mafiles_path) = new_args.mafiles_path {
-		mafiles_path
+	let mafiles_dir = if let Some(mafiles_path) = &new_args.mafiles_path {
+		mafiles_path.clone()
 	} else {
 		get_mafiles_dir()
 	};
@@ -185,7 +185,7 @@ fn run() -> anyhow::Result<()> {
 		manifest = accountmanager::Manifest::load(path.as_path())?;
 	}
 
-	let mut passkey: Option<String> = new_args.passkey;
+	let mut passkey: Option<String> = new_args.passkey.clone();
 	manifest.submit_passkey(passkey);
 
 	loop {
@@ -234,7 +234,7 @@ fn run() -> anyhow::Result<()> {
 
 	let mut selected_accounts: Vec<Arc<Mutex<SteamGuardAccount>>>;
 	loop {
-		match get_selected_accounts(&matches, &mut manifest) {
+		match get_selected_accounts(&new_args, &mut manifest) {
 			Ok(accounts) => {
 				selected_accounts = accounts;
 				break;
@@ -283,19 +283,19 @@ fn run() -> anyhow::Result<()> {
 }
 
 fn get_selected_accounts(
-	matches: &ArgMatches,
+	args: &cli::Args,
 	manifest: &mut accountmanager::Manifest,
 ) -> anyhow::Result<Vec<Arc<Mutex<SteamGuardAccount>>>, ManifestAccountLoadError> {
 	let mut selected_accounts: Vec<Arc<Mutex<SteamGuardAccount>>> = vec![];
 
-	if matches.is_present("all") {
+	if args.all {
 		manifest.load_accounts()?;
 		for entry in &manifest.entries {
 			selected_accounts.push(manifest.get_account(&entry.account_name).unwrap().clone());
 		}
 	} else {
-		let entry = if matches.is_present("username") {
-			manifest.get_entry(&matches.value_of("username").unwrap().into())
+		let entry = if let Some(username) = &args.username {
+			manifest.get_entry(&username)
 		} else {
 			manifest
 				.entries

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,10 +150,7 @@ fn run() -> anyhow::Result<()> {
 
 	match new_args.sub {
 		Some(cli::Subcommands::Debug(args)) => {
-			if args.demo_conf_menu {
-				demos::demo_confirmation_menu();
-			}
-			return Ok(());
+			return do_subcmd_debug(args);
 		},
 		// Subcommand::Completions{shell} => {
 		// 	// cli().gen_completions_to(
@@ -411,6 +408,13 @@ fn get_mafiles_dir() -> String {
 	}
 
 	return paths[0].to_str().unwrap().into();
+}
+
+fn do_subcmd_debug(args: cli::ArgsDebug) -> anyhow::Result<()> {
+	if args.demo_conf_menu {
+		demos::demo_confirmation_menu();
+	}
+	return Ok(());
 }
 
 fn do_subcmd_setup(args: cli::ArgsSetup, manifest: &mut accountmanager::Manifest) -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,7 +120,6 @@ fn cli() -> App<'static> {
 			App::new("debug")
 			.arg(
 				Arg::with_name("demo-conf-menu")
-				.help("Show an example confirmation menu using dummy data.")
 				.takes_value(false)
 			)
 		)

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,8 +174,8 @@ fn run() -> anyhow::Result<()> {
 		_ => {},
 	};
 
-	let mafiles_dir = if matches.occurrences_of("mafiles-path") > 0 {
-		matches.value_of("mafiles-path").unwrap().into()
+	let mafiles_dir = if let Some(mafiles_path) = new_args.mafiles_path {
+		mafiles_path
 	} else {
 		get_mafiles_dir()
 	};
@@ -202,7 +202,7 @@ fn run() -> anyhow::Result<()> {
 		manifest = accountmanager::Manifest::load(path.as_path())?;
 	}
 
-	let mut passkey: Option<String> = matches.value_of("passkey").map(|s| s.into());
+	let mut passkey: Option<String> = new_args.passkey;
 	manifest.submit_passkey(passkey);
 
 	loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ fn main() {
 
 fn run() -> anyhow::Result<()> {
 	let new_args = cli::Args::parse();
-	println!("{:?}", new_args);
+	info!("{:?}", new_args);
 
 	let matches = cli().get_matches();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 extern crate rpassword;
-use clap::{Parser, IntoApp};
+use clap::{IntoApp, Parser};
 use log::*;
 use std::{
 	io::{stdout, Write},
@@ -53,11 +53,11 @@ fn run() -> anyhow::Result<()> {
 	match args.sub {
 		Some(cli::Subcommands::Debug(args)) => {
 			return do_subcmd_debug(args);
-		},
+		}
 		Some(cli::Subcommands::Completion(args)) => {
 			return do_subcmd_completion(args);
-		},
-		_ => {},
+		}
+		_ => {}
 	};
 
 	let mafiles_dir = if let Some(mafiles_path) = &args.mafiles_path {
@@ -122,17 +122,17 @@ fn run() -> anyhow::Result<()> {
 	match args.sub {
 		Some(cli::Subcommands::Setup(args)) => {
 			return do_subcmd_setup(args, &mut manifest);
-		},
+		}
 		Some(cli::Subcommands::Import(args)) => {
 			return do_subcmd_import(args, &mut manifest);
-		},
+		}
 		Some(cli::Subcommands::Encrypt(args)) => {
 			return do_subcmd_encrypt(args, &mut manifest);
-		},
+		}
 		Some(cli::Subcommands::Decrypt(args)) => {
 			return do_subcmd_decrypt(args, &mut manifest);
-		},
-		_ => {},
+		}
+		_ => {}
 	}
 
 	let selected_accounts: Vec<Arc<Mutex<SteamGuardAccount>>>;
@@ -170,14 +170,14 @@ fn run() -> anyhow::Result<()> {
 	match args.sub {
 		Some(cli::Subcommands::Trade(args)) => {
 			return do_subcmd_trade(args, &mut manifest, selected_accounts);
-		},
+		}
 		Some(cli::Subcommands::Remove(args)) => {
 			return do_subcmd_remove(args, &mut manifest, selected_accounts);
-		},
+		}
 		Some(s) => {
 			error!("Unknown subcommand: {:?}", s);
 			return Err(errors::UserError::UnknownSubcommand.into());
-		},
+		}
 		_ => {
 			debug!("No subcommand given, assuming user wants a 2fa code");
 			return do_subcmd_code(selected_accounts);
@@ -319,7 +319,10 @@ fn do_subcmd_completion(args: cli::ArgsCompletions) -> Result<(), anyhow::Error>
 	return Ok(());
 }
 
-fn do_subcmd_setup(args: cli::ArgsSetup, manifest: &mut accountmanager::Manifest) -> anyhow::Result<()> {
+fn do_subcmd_setup(
+	args: cli::ArgsSetup,
+	manifest: &mut accountmanager::Manifest,
+) -> anyhow::Result<()> {
 	println!("Log in to the account that you want to link to steamguard-cli");
 	print!("Username: ");
 	let username = if args.username.is_some() {
@@ -336,8 +339,7 @@ fn do_subcmd_setup(args: cli::ArgsSetup, manifest: &mut accountmanager::Manifest
 			username
 		);
 	}
-	let session =
-		do_login_raw(username).expect("Failed to log in. Account has not been linked.");
+	let session = do_login_raw(username).expect("Failed to log in. Account has not been linked.");
 
 	let mut linker = AccountLinker::new(session);
 	let account: SteamGuardAccount;
@@ -434,7 +436,10 @@ fn do_subcmd_setup(args: cli::ArgsSetup, manifest: &mut accountmanager::Manifest
 	return Ok(());
 }
 
-fn do_subcmd_import(args: cli::ArgsImport, manifest: &mut accountmanager::Manifest) -> anyhow::Result<()> {
+fn do_subcmd_import(
+	args: cli::ArgsImport,
+	manifest: &mut accountmanager::Manifest,
+) -> anyhow::Result<()> {
 	for file_path in args.files {
 		match manifest.import_account(&file_path) {
 			Ok(_) => {
@@ -450,7 +455,11 @@ fn do_subcmd_import(args: cli::ArgsImport, manifest: &mut accountmanager::Manife
 	return Ok(());
 }
 
-fn do_subcmd_trade(args: cli::ArgsTrade, manifest: &mut accountmanager::Manifest, mut selected_accounts: Vec<Arc<Mutex<SteamGuardAccount>>>) -> anyhow::Result<()> {
+fn do_subcmd_trade(
+	args: cli::ArgsTrade,
+	manifest: &mut accountmanager::Manifest,
+	mut selected_accounts: Vec<Arc<Mutex<SteamGuardAccount>>>,
+) -> anyhow::Result<()> {
 	for a in selected_accounts.iter_mut() {
 		let mut account = a.lock().unwrap();
 
@@ -529,7 +538,11 @@ fn do_subcmd_trade(args: cli::ArgsTrade, manifest: &mut accountmanager::Manifest
 	return Ok(());
 }
 
-fn do_subcmd_remove(_args: cli::ArgsRemove, manifest: &mut accountmanager::Manifest, selected_accounts: Vec<Arc<Mutex<SteamGuardAccount>>>) -> anyhow::Result<()> {
+fn do_subcmd_remove(
+	_args: cli::ArgsRemove,
+	manifest: &mut accountmanager::Manifest,
+	selected_accounts: Vec<Arc<Mutex<SteamGuardAccount>>>,
+) -> anyhow::Result<()> {
 	println!(
 		"This will remove the mobile authenticator from {} accounts: {}",
 		selected_accounts.len(),
@@ -589,7 +602,10 @@ fn do_subcmd_remove(_args: cli::ArgsRemove, manifest: &mut accountmanager::Manif
 	return Ok(());
 }
 
-fn do_subcmd_encrypt(_args: cli::ArgsEncrypt, manifest: &mut accountmanager::Manifest) -> anyhow::Result<()> {
+fn do_subcmd_encrypt(
+	_args: cli::ArgsEncrypt,
+	manifest: &mut accountmanager::Manifest,
+) -> anyhow::Result<()> {
 	if !manifest.has_passkey() {
 		let mut passkey;
 		loop {
@@ -611,7 +627,10 @@ fn do_subcmd_encrypt(_args: cli::ArgsEncrypt, manifest: &mut accountmanager::Man
 	return Ok(());
 }
 
-fn do_subcmd_decrypt(_args: cli::ArgsDecrypt, manifest: &mut accountmanager::Manifest) -> anyhow::Result<()> {
+fn do_subcmd_decrypt(
+	_args: cli::ArgsDecrypt,
+	manifest: &mut accountmanager::Manifest,
+) -> anyhow::Result<()> {
 	manifest.load_accounts()?;
 	for entry in &mut manifest.entries {
 		entry.encryption = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,13 +65,6 @@ fn cli() -> App<'static> {
 				.help("Specify your encryption passkey.")
 				.takes_value(true)
 		)
-		.arg(
-			Arg::with_name("verbosity")
-				.short('v')
-				.help("Log what is going on verbosely.")
-				.takes_value(false)
-				.multiple(true)
-		)
 		// .subcommand(
 		// 	App::new("completion")
 		// 		.about("Generate shell completions")

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,7 +229,9 @@ fn run() -> anyhow::Result<()> {
 		Some(cli::Subcommands::Setup(args)) => {
 			return do_subcmd_setup(args, &mut manifest);
 		},
-		Some(cli::Subcommands::Import(args)) => {todo!()},
+		Some(cli::Subcommands::Import(args)) => {
+			return do_subcmd_import(args, &mut manifest);
+		},
 		Some(cli::Subcommands::Encrypt(args)) => {
 			return do_subcmd_encrypt(args, &mut manifest);
 		},
@@ -237,22 +239,6 @@ fn run() -> anyhow::Result<()> {
 			return do_subcmd_decrypt(args, &mut manifest);
 		},
 		_ => {},
-	}
-
-	if let Some(import_matches) = matches.subcommand_matches("import") {
-		for file_path in import_matches.values_of("files").unwrap() {
-			match manifest.import_account(file_path.into()) {
-				Ok(_) => {
-					info!("Imported account: {}", file_path);
-				}
-				Err(err) => {
-					bail!("Failed to import account: {} {}", file_path, err);
-				}
-			}
-		}
-
-		manifest.save()?;
-		return Ok(());
 	}
 
 	let mut selected_accounts: Vec<Arc<Mutex<SteamGuardAccount>>>;
@@ -679,6 +665,22 @@ fn do_subcmd_setup(args: cli::ArgsSetup, manifest: &mut accountmanager::Manifest
 		account.revocation_code
 	);
 
+	return Ok(());
+}
+
+fn do_subcmd_import(args: cli::ArgsImport, manifest: &mut accountmanager::Manifest) -> anyhow::Result<()> {
+	for file_path in args.files {
+		match manifest.import_account(&file_path) {
+			Ok(_) => {
+				info!("Imported account: {}", &file_path);
+			}
+			Err(err) => {
+				bail!("Failed to import account: {} {}", &file_path, err);
+			}
+		}
+	}
+
+	manifest.save()?;
 	return Ok(());
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 extern crate rpassword;
-use clap::{crate_version, App, Arg, ArgMatches, Parser, Subcommand};
+use clap::{crate_version, App, Arg, ArgMatches, Parser, IntoApp};
 use log::*;
 use std::{
 	io::{stdout, Write},
@@ -11,7 +11,7 @@ use steamguard::{
 	SteamGuardAccount, UserLogin,
 };
 
-use crate::{accountmanager::ManifestAccountLoadError, cli::Subcommands};
+use crate::{accountmanager::ManifestAccountLoadError};
 
 #[macro_use]
 extern crate lazy_static;
@@ -65,16 +65,15 @@ fn cli() -> App<'static> {
 				.help("Specify your encryption passkey.")
 				.takes_value(true)
 		)
-		// .subcommand(
-		// 	App::new("completion")
-		// 		.about("Generate shell completions")
-		// 		.arg(
-		// 			Arg::with_name("shell")
-		// 				.long("shell")
-		// 				.takes_value(true)
-		// 				.possible_values(&Shell::variants())
-		// 		)
-		// )
+		.subcommand(
+			App::new("completion")
+				.about("Generate shell completions")
+				.arg(
+					Arg::with_name("shell")
+						.long("shell")
+						.takes_value(true)
+				)
+		)
 		.subcommand(
 			App::new("trade")
 				.about("Interactive interface for trade confirmations")
@@ -152,14 +151,9 @@ fn run() -> anyhow::Result<()> {
 		Some(cli::Subcommands::Debug(args)) => {
 			return do_subcmd_debug(args);
 		},
-		// Subcommand::Completions{shell} => {
-		// 	// cli().gen_completions_to(
-		// 	// 	"steamguard",
-		// 	// 	Shell::from_str(completion_matches.value_of("shell").unwrap()).unwrap(),
-		// 	// 	&mut std::io::stdout(),
-		// 	// );
-		// 	return Ok(());
-		// },
+		Some(cli::Subcommands::Completion(args)) => {
+			return do_subcmd_completion(args);
+		},
 		_ => {},
 	};
 
@@ -414,6 +408,12 @@ fn do_subcmd_debug(args: cli::ArgsDebug) -> anyhow::Result<()> {
 	if args.demo_conf_menu {
 		demos::demo_confirmation_menu();
 	}
+	return Ok(());
+}
+
+fn do_subcmd_completion(args: cli::ArgsCompletions) -> Result<(), anyhow::Error> {
+	let mut app = cli::Args::command_for_update();
+	clap_complete::generate(args.shell, &mut app, "steamguard", &mut std::io::stdout());
 	return Ok(());
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,14 +273,13 @@ fn run() -> anyhow::Result<()> {
 		},
 		Some(s) => {
 			error!("Unknown subcommand: {:?}", s);
+			return Err(errors::UserError::UnknownSubcommand.into());
 		},
 		_ => {
 			debug!("No subcommand given, assuming user wants a 2fa code");
 			return do_subcmd_code(selected_accounts);
 		}
 	}
-
-	Ok(())
 }
 
 fn get_selected_accounts(

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,18 +285,7 @@ fn run() -> anyhow::Result<()> {
 		},
 		_ => {
 			debug!("No subcommand given, assuming user wants a 2fa code");
-
-			let server_time = steamapi::get_server_time();
-			debug!("Time used to generate codes: {}", server_time);
-			for account in selected_accounts {
-				info!(
-					"Generating code for {}",
-					account.lock().unwrap().account_name
-				);
-				trace!("{:?}", account);
-				let code = account.lock().unwrap().generate_code(server_time);
-				println!("{}", code);
-			}
+			return do_subcmd_code(selected_accounts);
 		}
 	}
 
@@ -723,5 +712,20 @@ fn do_subcmd_decrypt(args: cli::ArgsDecrypt, manifest: &mut accountmanager::Mani
 	}
 	manifest.submit_passkey(None);
 	manifest.save()?;
+	return Ok(());
+}
+
+fn do_subcmd_code(selected_accounts: Vec<Arc<Mutex<SteamGuardAccount>>>) -> anyhow::Result<()> {
+	let server_time = steamapi::get_server_time();
+	debug!("Time used to generate codes: {}", server_time);
+	for account in selected_accounts {
+		info!(
+			"Generating code for {}",
+			account.lock().unwrap().account_name
+		);
+		trace!("{:?}", account);
+		let code = account.lock().unwrap().generate_code(server_time);
+		println!("{}", code);
+	}
 	return Ok(());
 }


### PR DESCRIPTION
- upgrade to clap v3, convert global level arguments
- convert most of the remaining arg definitions
- converted some subcommands
- add subcommand arg types
- move args definitions to new file
- make it compile again
- switch to a better setup for subcommands
- swtich mafiles path to new args
- remove old verbosity arg
- move help text
- move encrypt and decrypt subcommand impls to functions
- move import subcommand impl
- move trade and remove subcommand impls
- move generate code subcommand impl
- move debug subcommand impl
- reimplement completion subcommand
- change debug line
- fix arg parsing for shell arg
- set name and bin_name metadata
- return better error for unimplemented subcommand
- add arg_enum marker for verbosity arg
- improve help test for verbosity
- switch get_selected_accounts to new args
- add conflicts_with arg metadata
- remove old arg parsing completely
- fix some warnings

closes #135

