### PR TITLE
Switch to crossterm library for terminal ui stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "futures-core",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,6 +1742,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1871,6 +1927,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "cookie 0.14.4",
+ "crossterm",
  "dirs",
  "hmac-sha1",
  "lazy_static 1.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,7 +1945,6 @@ dependencies = [
  "stderrlog",
  "steamguard",
  "tempdir",
- "termion",
  "text_io",
  "thiserror",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ ring = "0.16.20"
 aes = "0.7.4"
 block-modes = "0.8.1"
 thiserror = "1.0.26"
+crossterm = { version = "0.23.2", features = ["event-stream"] }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ cookie = "0.14"
 regex = "1"
 lazy_static = "1.4.0"
 uuid = { version = "0.8", features = ["v4"] }
-termion = "1.5.6"
 steamguard = { version ="^0.4.2", path = "./steamguard" }
 dirs = "3.0.2"
 ring = "0.16.20"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -99,6 +99,10 @@ impl FromStr for Verbosity {
 #[derive(Debug, Clone, Parser)]
 #[clap(about = "Debug stuff, not useful for most users.")]
 pub(crate) struct ArgsDebug {
+	#[clap(long, help = "Show a text prompt.")]
+	pub demo_prompt: bool,
+	#[clap(long, help = "Show a character prompt.")]
+	pub demo_prompt_char: bool,
 	#[clap(long, help = "Show an example confirmation menu using dummy data.")]
 	pub demo_conf_menu: bool,
 }

--- a/src/demos.rs
+++ b/src/demos.rs
@@ -33,6 +33,6 @@ pub fn demo_confirmation_menu() {
 			creator: 09870987,
 			description: "example confirmation".into(),
 		},
-	]);
+	]).expect("confirmation menu demo failed");
 	println!("accept: {}, deny: {}", accept.len(), deny.len());
 }

--- a/src/demos.rs
+++ b/src/demos.rs
@@ -2,6 +2,22 @@ use crate::tui;
 use log::*;
 use steamguard::{Confirmation, ConfirmationType};
 
+pub fn demo_prompt() {
+	print!("Prompt: ");
+	let result = tui::prompt();
+	println!("Result: {}", result);
+}
+
+pub fn demo_prompt_char() {
+	println!("Showing prompt");
+	let result = tui::prompt_char("Continue?", "yn");
+	println!("Result: {}", result);
+	let result = tui::prompt_char("Continue?", "Yn");
+	println!("Result: {}", result);
+	let result = tui::prompt_char("Continue?", "yN");
+	println!("Result: {}", result);
+}
+
 pub fn demo_confirmation_menu() {
 	info!("showing demo menu");
 	let (accept, deny) = tui::prompt_confirmation_menu(vec![
@@ -33,6 +49,7 @@ pub fn demo_confirmation_menu() {
 			creator: 09870987,
 			description: "example confirmation".into(),
 		},
-	]).expect("confirmation menu demo failed");
+	])
+	.expect("confirmation menu demo failed");
 	println!("accept: {}, deny: {}", accept.len(), deny.len());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 extern crate rpassword;
 use clap::{IntoApp, Parser};
+use crossterm::tty::IsTty;
 use log::*;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
@@ -7,7 +8,6 @@ use std::{
 	path::Path,
 	sync::{Arc, Mutex},
 };
-use crossterm::tty::IsTty;
 use steamguard::{
 	steamapi, AccountLinkError, AccountLinker, Confirmation, ExposeSecret, FinalizeLinkError,
 	LoginError, SteamGuardAccount, UserLogin,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ mod cli;
 mod demos;
 mod encryption;
 mod errors;
-mod tui;
+pub(crate) mod tui;
 
 fn main() {
 	std::process::exit(match run() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use std::{
 	path::Path,
 	sync::{Arc, Mutex},
 };
+use crossterm::tty::IsTty;
 use steamguard::{
 	steamapi, AccountLinkError, AccountLinker, Confirmation, ExposeSecret, FinalizeLinkError,
 	LoginError, SteamGuardAccount, UserLogin,
@@ -522,7 +523,7 @@ fn do_subcmd_trade(
 				}
 			}
 		} else {
-			if termion::is_tty(&stdout()) {
+			if stdout().is_tty() {
 				let (accept, deny) = tui::prompt_confirmation_menu(confirmations)?;
 				for conf in &accept {
 					let result = account.accept_confirmation(conf);

--- a/src/main.rs
+++ b/src/main.rs
@@ -517,7 +517,7 @@ fn do_subcmd_trade(
 			}
 		} else {
 			if termion::is_tty(&stdout()) {
-				let (accept, deny) = tui::prompt_confirmation_menu(confirmations);
+				let (accept, deny) = tui::prompt_confirmation_menu(confirmations)?;
 				for conf in &accept {
 					let result = account.accept_confirmation(conf);
 					if result.is_err() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -329,6 +329,12 @@ fn load_accounts_with_prompts(manifest: &mut accountmanager::Manifest) -> anyhow
 }
 
 fn do_subcmd_debug(args: cli::ArgsDebug) -> anyhow::Result<()> {
+	if args.demo_prompt {
+		demos::demo_prompt();
+	}
+	if args.demo_prompt_char {
+		demos::demo_prompt_char();
+	}
 	if args.demo_conf_menu {
 		demos::demo_confirmation_menu();
 	}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -285,36 +285,33 @@ mod prompt_char_tests {
 
 	#[test]
 	fn test_gives_answer() {
-		let inputs = ['y', '\n'].iter().collect::<String>();
-		let answer = prompt_char_impl(inputs, "yn").unwrap();
+		let answer = prompt_char_impl("y", "yn").unwrap();
 		assert_eq!(answer, 'y');
 	}
 
 	#[test]
 	fn test_gives_default() {
-		let inputs = ['\n'].iter().collect::<String>();
-		let answer = prompt_char_impl(inputs, "Yn").unwrap();
+		let answer = prompt_char_impl("", "Yn").unwrap();
 		assert_eq!(answer, 'y');
 	}
 
 	#[test]
 	fn test_should_not_give_default() {
-		let inputs = ['n', '\n'].iter().collect::<String>();
-		let answer = prompt_char_impl(inputs, "Yn").unwrap();
+		let answer = prompt_char_impl("n", "Yn").unwrap();
 		assert_eq!(answer, 'n');
 	}
 
 	#[test]
 	fn test_should_not_give_invalid() {
-		let inputs = ['g', '\n', 'n', '\n'].iter().collect::<String>();
-		let answer = prompt_char_impl(inputs, "yn").unwrap();
+		let answer = prompt_char_impl("g", "yn");
+		assert!(matches!(answer, Err(_)));
+		let answer = prompt_char_impl("n", "yn").unwrap();
 		assert_eq!(answer, 'n');
 	}
 
 	#[test]
 	fn test_should_not_give_multichar() {
-		let inputs = ['y', 'y', '\n', 'n', '\n'].iter().collect::<String>();
-		let answer = prompt_char_impl(inputs, "yn").unwrap();
-		assert_eq!(answer, 'n');
+		let answer = prompt_char_impl("yy", "yn");
+		assert!(matches!(answer, Err(_)));
 	}
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -38,7 +38,7 @@ fn test_validate_captcha_text() {
 }
 
 /// Prompt the user for text input.
-pub fn prompt() -> String {
+pub(crate) fn prompt() -> String {
 	let mut text = String::new();
 	let _ = std::io::stdout().flush();
 	std::io::stdin()
@@ -47,7 +47,7 @@ pub fn prompt() -> String {
 	return String::from(text.strip_suffix('\n').unwrap());
 }
 
-pub fn prompt_captcha_text(captcha_gid: &String) -> String {
+pub(crate) fn prompt_captcha_text(captcha_gid: &String) -> String {
 	println!("Captcha required. Open this link in your web browser: https://steamcommunity.com/public/captcha.php?gid={}", captcha_gid);
 	let mut captcha_text;
 	loop {
@@ -64,7 +64,7 @@ pub fn prompt_captcha_text(captcha_gid: &String) -> String {
 /// Prompt the user for a single character response. Useful for asking yes or no questions.
 ///
 /// `chars` should be all lowercase characters, with at most 1 uppercase character. The uppercase character is the default answer if no answer is provided.
-pub fn prompt_char(text: &str, chars: &str) -> char {
+pub(crate) fn prompt_char(text: &str, chars: &str) -> char {
 	return prompt_char_impl(&mut std::io::stdin(), text, chars);
 }
 
@@ -103,7 +103,7 @@ fn prompt_char_impl(input: &mut impl Read, text: &str, chars: &str) -> char {
 }
 
 /// Returns a tuple of (accepted, denied). Ignored confirmations are not included.
-pub fn prompt_confirmation_menu(
+pub(crate) fn prompt_confirmation_menu(
 	confirmations: Vec<Confirmation>,
 ) -> (Vec<Confirmation>, Vec<Confirmation>) {
 	println!("press a key other than enter to show the menu.");
@@ -225,7 +225,7 @@ pub fn prompt_confirmation_menu(
 	);
 }
 
-pub fn pause() {
+pub(crate) fn pause() {
 	println!("Press any key to continue...");
 	let mut stdout = std::io::stdout().into_raw_mode().unwrap();
 	stdout.flush().unwrap();


### PR DESCRIPTION
- adjust visibility of some functions/modules
- add crossterm to cargo.toml
- convert prompt_confirmation_menu to crossterm
- converted remaining tui module to crossterm
- replace tty check with crossterm
- remove termion
- fix up unit tests

closes #123
