### PR TITLE
add SteamGuardAccount::from_reader

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -125,6 +125,10 @@ where
 pub(crate) fn prompt_confirmation_menu(
 	confirmations: Vec<Confirmation>,
 ) -> anyhow::Result<(Vec<Confirmation>, Vec<Confirmation>)> {
+	if confirmations.len() == 0 {
+		bail!("no confirmations")
+	}
+
 	let mut to_accept_idx: HashSet<usize> = HashSet::new();
 	let mut to_deny_idx: HashSet<usize> = HashSet::new();
 

--- a/steamguard/src/lib.rs
+++ b/steamguard/src/lib.rs
@@ -13,7 +13,7 @@ use reqwest::{
 use scraper::{Html, Selector};
 pub use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, convert::TryInto};
+use std::{collections::HashMap, convert::TryInto, io::Read};
 use steamapi::SteamApiClient;
 pub use userlogin::{LoginError, UserLogin};
 #[macro_use]
@@ -92,6 +92,13 @@ impl SteamGuardAccount {
 			secret_1: String::from("").into(),
 			session: Option::None,
 		};
+	}
+
+	pub fn from_reader<T>(r: T) -> anyhow::Result<Self>
+	where
+		T: Read,
+	{
+		Ok(serde_json::from_reader(r)?)
 	}
 
 	pub fn set_session(&mut self, session: steamapi::Session) {


### PR DESCRIPTION
- add check in prompt_confirmation_menu to make sure confirmations is not empty
- steamguard: add SteamGuardAccount::from_reader
