### PR TITLE
fix prompts sometimes not showing up (again)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,6 +103,8 @@ impl FromStr for Verbosity {
 pub(crate) struct ArgsDebug {
 	#[clap(long, help = "Show a text prompt.")]
 	pub demo_prompt: bool,
+	#[clap(long, help = "Show a \"press any key\" prompt.")]
+	pub demo_pause: bool,
 	#[clap(long, help = "Show a character prompt.")]
 	pub demo_prompt_char: bool,
 	#[clap(long, help = "Show an example confirmation menu using dummy data.")]

--- a/src/demos.rs
+++ b/src/demos.rs
@@ -8,6 +8,15 @@ pub fn demo_prompt() {
 	println!("Result: {}", result);
 }
 
+pub fn demo_pause() {
+	let mut x = 0;
+	loop {
+		tui::pause();
+		x += 1;
+		println!("looped {} times", x);
+	}
+}
+
 pub fn demo_prompt_char() {
 	println!("Showing prompt");
 	let result = tui::prompt_char("Continue?", "yn");

--- a/src/main.rs
+++ b/src/main.rs
@@ -339,6 +339,9 @@ fn do_subcmd_debug(args: cli::ArgsDebug) -> anyhow::Result<()> {
 	if args.demo_prompt {
 		demos::demo_prompt();
 	}
+	if args.demo_pause {
+		demos::demo_pause();
+	}
 	if args.demo_prompt_char {
 		demos::demo_prompt_char();
 	}

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,9 +222,9 @@ fn get_selected_accounts(
 
 fn do_login(account: &mut SteamGuardAccount) -> anyhow::Result<()> {
 	if account.account_name.len() > 0 {
-		println!("Username: {}", account.account_name);
+		info!("Username: {}", account.account_name);
 	} else {
-		print!("Username: ");
+		eprint!("Username: ");
 		account.account_name = tui::prompt();
 	}
 	let _ = std::io::stdout().flush();
@@ -361,8 +361,8 @@ fn do_subcmd_setup(
 	_args: cli::ArgsSetup,
 	manifest: &mut accountmanager::Manifest,
 ) -> anyhow::Result<()> {
-	println!("Log in to the account that you want to link to steamguard-cli");
-	print!("Username: ");
+	eprintln!("Log in to the account that you want to link to steamguard-cli");
+	eprint!("Username: ");
 	let username = tui::prompt().to_lowercase();
 	let account_name = username.clone();
 	if manifest.account_exists(&username) {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -41,7 +41,7 @@ fn test_validate_captcha_text() {
 
 /// Prompt the user for text input.
 pub(crate) fn prompt() -> String {
-	stderr().flush().unwrap();
+	stderr().flush().expect("failed to flush stderr");
 
 	let mut line = String::new();
 	while let Event::Key(KeyEvent { code, .. }) = crossterm::event::read().unwrap() {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -273,11 +273,14 @@ pub(crate) fn prompt_confirmation_menu(
 }
 
 pub(crate) fn pause() {
-	eprintln!("Press any key to continue...");
+	let _ = write!(stderr(), "Press enter to continue...");
 	let _ = stderr().flush();
 	loop {
 		match crossterm::event::read().expect("could not read terminal events") {
-			Event::Key(_) => break,
+			Event::Key(KeyEvent {
+				code: KeyCode::Enter,
+				..
+			}) => break,
 			_ => continue,
 		}
 	}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -41,6 +41,7 @@ fn test_validate_captcha_text() {
 
 /// Prompt the user for text input.
 pub(crate) fn prompt() -> String {
+	stdout().flush().expect("failed to flush stdout");
 	stderr().flush().expect("failed to flush stderr");
 
 	let mut line = String::new();


### PR DESCRIPTION
- fix tui::pause only accept enter  to continue so it's less confusing
- replace unwrap with flush
- replace some prints with eprints
- make tui::prompt flush stdout and stderr

fixes #178
