### PR TITLE
Change steamguard-cli command to steamguard in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ steamguard --help
 
 Generate and copy a new code to clipboard:
 ```bash
-steamguard-cli | xclip -selection clipboard
+steamguard | xclip -selection clipboard
 ```
 
 ## Importing 2FA Secret Into Other Applications


### PR DESCRIPTION
A very minor pull request for a small (I believe) mistake in the `README.md`. The command for generating and copying a new code to the clipboard used `steamguard-cli` as command which took me a bit off guard and made me question if I installed steamguard-cli correctly.

This PR changes it to `steamguard`.