### PR TITLE
Remove debug print to stdout in `trade` sub command

### DIFF
--- a/steamguard/src/lib.rs
+++ b/steamguard/src/lib.rs
@@ -163,7 +163,7 @@ impl SteamGuardAccount {
 		trace!("{:?}", resp);
 		let text = resp.text().unwrap();
 		trace!("text: {:?}", text);
-		println!("{}", text);
+		trace!("{}", text);
 		return parse_confirmations(text);
 	}
 


### PR DESCRIPTION
Every time when the `trade` sub command is executed, the webpage gets printed to stdout which is a bit irritating and unnecessary.

This PR fixes this, in that it changes the `println!` macro to a `trace!` macro.