### PR TITLE
Add env option to configure maFiles path

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -93,6 +93,7 @@ pub(crate) struct GlobalArgs {
 	#[clap(
 		short,
 		long,
+		env = "STEAMGUARD_CLI_MAFILES",
 		help = "Specify which folder your maFiles are in. This should be a path to a folder that contains manifest.json. Default: ~/.config/steamguard-cli/maFiles"
 	)]
 	pub mafiles_path: Option<String>,


### PR DESCRIPTION
I'd like to add this awesome tool to Scoop (https://github.com/ScoopInstaller/Scoop) which works best with portable programs.
Currently the problem is that steamguard-cli doesn't look for a local/relative maFiles folder.
The alternative I opted for would be to use an env var which Scoop can also set to its persist dir.