### PR TITLE
import: add support for importing steam mobile app v2 format, remove `--sda` argument

### DIFF
--- a/src/accountmanager.rs
+++ b/src/accountmanager.rs
@@ -15,6 +15,7 @@ use thiserror::Error;
 mod legacy;
 pub mod manifest;
 pub mod migrate;
+mod steamv2;
 
 pub use manifest::*;
 

--- a/src/accountmanager/migrate.rs
+++ b/src/accountmanager/migrate.rs
@@ -381,6 +381,11 @@ mod tests {
 				account_name: "example",
 				steam_id: 1234,
 			},
+			Test {
+				mafile: "src/fixtures/maFiles/compat/steamv2/sample.maFile",
+				account_name: "afarihm",
+				steam_id: 76561199441992970,
+			},
 		];
 		for case in cases {
 			eprintln!("testing: {:?}", case);

--- a/src/accountmanager/migrate.rs
+++ b/src/accountmanager/migrate.rs
@@ -262,7 +262,9 @@ impl From<MigratingAccount> for SteamGuardAccount {
 
 pub fn load_and_upgrade_external_account(path: &Path) -> anyhow::Result<SteamGuardAccount> {
 	let file = File::open(path)?;
-	let account: ExternalAccount = serde_json::from_reader(file)?;
+	let mut deser = serde_json::Deserializer::from_reader(&file);
+	let account: ExternalAccount = serde_path_to_error::deserialize(&mut deser)
+		.map_err(|err| anyhow::anyhow!("Failed to deserialize account: {}", err))?;
 	let mut account = MigratingAccount::External(account);
 	while !account.is_latest() {
 		account = account.upgrade();

--- a/src/accountmanager/migrate.rs
+++ b/src/accountmanager/migrate.rs
@@ -233,6 +233,7 @@ fn deserialize_manifest(
 }
 
 #[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
 enum MigratingAccount {
 	External(ExternalAccount),
 	ManifestV1(SteamGuardAccount),
@@ -275,6 +276,7 @@ pub fn load_and_upgrade_external_account(path: &Path) -> anyhow::Result<SteamGua
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 enum ExternalAccount {
 	Sda(SdaAccount),
 	SteamMobileV2(SteamMobileV2),

--- a/src/accountmanager/steamv2.rs
+++ b/src/accountmanager/steamv2.rs
@@ -30,7 +30,7 @@ pub struct SteamMobileV2 {
 	pub revocation_code: SecretString,
 	#[serde(with = "crate::secret_string")]
 	pub uri: SecretString,
-	pub server_time: Option<String>,
+	pub server_time: Option<serde_json::Value>,
 	pub account_name: String,
 	pub token_gid: String,
 	#[serde(with = "crate::secret_string")]

--- a/src/accountmanager/steamv2.rs
+++ b/src/accountmanager/steamv2.rs
@@ -32,15 +32,15 @@ pub struct SteamMobileV2 {
 	pub revocation_code: SecretString,
 	#[serde(with = "crate::secret_string")]
 	pub uri: SecretString,
-	pub server_time: serde_json::Value,
+	pub server_time: Option<serde_json::Value>,
 	pub account_name: String,
 	pub token_gid: String,
 	#[serde(with = "crate::secret_string")]
 	pub identity_secret: SecretString,
 	#[serde(with = "crate::secret_string")]
 	pub secret_1: SecretString,
-	pub status: serde_json::Value,
-	pub steamguard_scheme: serde_json::Value,
+	pub status: Option<serde_json::Value>,
+	pub steamguard_scheme: Option<serde_json::Value>,
 }
 
 impl From<SteamMobileV2> for SteamGuardAccount {

--- a/src/accountmanager/steamv2.rs
+++ b/src/accountmanager/steamv2.rs
@@ -1,0 +1,60 @@
+use secrecy::SecretString;
+use serde::Deserialize;
+use steamguard::{token::TwoFactorSecret, SteamGuardAccount};
+use uuid::Uuid;
+
+/// Defines the schema for loading steamguard accounts extracted from backups of the official Steam app (v2).
+///
+/// ```json
+/// {
+/// 	"steamid": "X",
+/// 	"shared_secret": "X",
+/// 	"serial_number": "X",
+/// 	"revocation_code": "X",
+/// 	"uri": "otpauth:\/\/totp\/Steam:USERNAME?secret=X&issuer=Steam",
+/// 	"server_time": "X",
+/// 	"account_name": "USERNAME",
+/// 	"token_gid": "X",
+/// 	"identity_secret": "X",
+/// 	"secret_1": "X",
+/// 	"status": 1,
+/// 	"steamguard_scheme": "2"
+/// }
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+pub struct SteamMobileV2 {
+	pub steamid: u64,
+	pub shared_secret: TwoFactorSecret,
+	pub serial_number: String,
+	#[serde(with = "crate::secret_string")]
+	pub revocation_code: SecretString,
+	#[serde(with = "crate::secret_string")]
+	pub uri: SecretString,
+	pub server_time: Option<String>,
+	pub account_name: String,
+	pub token_gid: String,
+	#[serde(with = "crate::secret_string")]
+	pub identity_secret: SecretString,
+	pub status: Option<String>,
+	pub steamguard_scheme: Option<String>,
+}
+
+impl From<SteamMobileV2> for SteamGuardAccount {
+	fn from(account: SteamMobileV2) -> Self {
+		Self {
+			shared_secret: account.shared_secret,
+			identity_secret: account.identity_secret,
+			revocation_code: account.revocation_code,
+			uri: account.uri,
+			account_name: account.account_name,
+			token_gid: account.token_gid,
+			serial_number: account.serial_number,
+			steam_id: account.steamid,
+			// device_id is unknown, so we just make one up
+			device_id: format!("android:{}", Uuid::new_v4()),
+			// secret_1 is unknown, so we just set it to all zeros base64 encoded
+			secret_1: SecretString::new("AAAAAAAAAAAAAAAAAAAAAAAAAAA=".to_owned()),
+			tokens: None,
+		}
+	}
+}

--- a/src/accountmanager/steamv2.rs
+++ b/src/accountmanager/steamv2.rs
@@ -8,18 +8,18 @@ use uuid::Uuid;
 ///
 /// ```json
 /// {
-/// 	"steamid": "X",
-/// 	"shared_secret": "X",
-/// 	"serial_number": "X",
-/// 	"revocation_code": "X",
-/// 	"uri": "otpauth:\/\/totp\/Steam:USERNAME?secret=X&issuer=Steam",
-/// 	"server_time": "X",
-/// 	"account_name": "USERNAME",
-/// 	"token_gid": "X",
-/// 	"identity_secret": "X",
-/// 	"secret_1": "X",
-/// 	"status": 1,
-/// 	"steamguard_scheme": "2"
+///     "steamid": "X",
+///     "shared_secret": "X",
+///     "serial_number": "X",
+///     "revocation_code": "X",
+///     "uri": "otpauth:\/\/totp\/Steam:USERNAME?secret=X&issuer=Steam",
+///     "server_time": "X",
+///     "account_name": "USERNAME",
+///     "token_gid": "X",
+///     "identity_secret": "X",
+///     "secret_1": "X",
+///     "status": 1,
+///     "steamguard_scheme": "2"
 /// }
 /// ```
 #[derive(Debug, Clone, Deserialize)]
@@ -67,7 +67,7 @@ fn de_parse_number<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u64, D:
 		Value::String(s) => s.parse().map_err(serde::de::Error::custom)?,
 		Value::Number(num) => num
 			.as_u64()
-			.ok_or(serde::de::Error::custom("Invalid number"))? as u64,
+			.ok_or(serde::de::Error::custom("Invalid number"))?,
 		_ => return Err(serde::de::Error::custom("wrong type")),
 	})
 }

--- a/src/accountmanager/steamv2.rs
+++ b/src/accountmanager/steamv2.rs
@@ -35,6 +35,8 @@ pub struct SteamMobileV2 {
 	pub token_gid: String,
 	#[serde(with = "crate::secret_string")]
 	pub identity_secret: SecretString,
+	#[serde(with = "crate::secret_string")]
+	pub secret_1: SecretString,
 	pub status: Option<String>,
 	pub steamguard_scheme: Option<String>,
 }
@@ -52,8 +54,7 @@ impl From<SteamMobileV2> for SteamGuardAccount {
 			steam_id: account.steamid,
 			// device_id is unknown, so we just make one up
 			device_id: format!("android:{}", Uuid::new_v4()),
-			// secret_1 is unknown, so we just set it to all zeros base64 encoded
-			secret_1: SecretString::new("AAAAAAAAAAAAAAAAAAAAAAAAAAA=".to_owned()),
+			secret_1: account.secret_1,
 			tokens: None,
 		}
 	}

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -11,9 +11,6 @@ use super::*;
 	about = "Import an account with steamguard already set up. It must not be encrypted. If you haven't used steamguard-cli before, you probably don't need to use this command."
 )]
 pub struct ImportCommand {
-	#[clap(long, help = "Whether or not the provided maFiles are from SDA.")]
-	pub sda: bool,
-
 	#[clap(long, help = "Paths to one or more maFiles, eg. \"./gaben.maFile\"")]
 	pub files: Vec<String>,
 }
@@ -25,27 +22,33 @@ where
 	fn execute(&self, _transport: T, manager: &mut AccountManager) -> anyhow::Result<()> {
 		for file_path in self.files.iter() {
 			debug!("loading entry: {:?}", file_path);
-			if self.sda {
-				let path = Path::new(&file_path);
-				let account =
-					crate::accountmanager::migrate::load_and_upgrade_external_account(path)?;
-				manager.add_account(account);
-				info!("Imported account: {}", &file_path);
-			} else {
-				match manager.import_account(file_path) {
-					Ok(_) => {
-						info!("Imported account: {}", &file_path);
-					}
-					Err(ManifestAccountImportError::AlreadyExists { .. }) => {
-						warn!("Account already exists: {} -- Ignoring", &file_path);
-					}
-					Err(ManifestAccountImportError::DeserializationFailed(err)) => {
-						warn!("Failed to import account: {} {}", &file_path, err);
-						warn!("If this file came from SDA, try using --sda");
-					}
-					Err(err) => {
-						bail!("Failed to import account: {} {}", &file_path, err);
-					}
+			match manager.import_account(file_path) {
+				Ok(_) => {
+					info!("Imported account: {}", &file_path);
+				}
+				Err(ManifestAccountImportError::AlreadyExists { .. }) => {
+					warn!("Account already exists: {} -- Ignoring", &file_path);
+				}
+				Err(ManifestAccountImportError::DeserializationFailed(orig_err)) => {
+					debug!("Falling back to external account import",);
+
+					let path = Path::new(&file_path);
+					let account =
+						match crate::accountmanager::migrate::load_and_upgrade_external_account(
+							path,
+						) {
+							Ok(account) => account,
+							Err(err) => {
+								error!("Failed to import account: {} {}", &file_path, err);
+								error!("The original error was: {}", orig_err);
+								continue;
+							}
+						};
+					manager.add_account(account);
+					info!("Imported account: {}", &file_path);
+				}
+				Err(err) => {
+					bail!("Failed to import account: {} {}", &file_path, err);
 				}
 			}
 		}

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -27,7 +27,8 @@ where
 			debug!("loading entry: {:?}", file_path);
 			if self.sda {
 				let path = Path::new(&file_path);
-				let account = crate::accountmanager::migrate::load_and_upgrade_sda_account(path)?;
+				let account =
+					crate::accountmanager::migrate::load_and_upgrade_external_account(path)?;
 				manager.add_account(account);
 				info!("Imported account: {}", &file_path);
 			} else {

--- a/src/fixtures/maFiles/compat/steamv2/sample.maFile
+++ b/src/fixtures/maFiles/compat/steamv2/sample.maFile
@@ -1,0 +1,14 @@
+{
+	"steamid": "76561199441992970",
+	"shared_secret": "kSJa7hfbr8IvReG9/1Ax13BhTJA=",
+	"serial_number": "5182004572898897156",
+	"revocation_code": "R52260",
+	"uri": "otpauth://totp/Steam:afarihm?secret=SERFV3QX3OX4EL2F4G676UBR25YGCTEQ&issuer=Steam",
+	"server_time": "123",
+	"account_name": "afarihm",
+	"token_gid": "2d5a1b6cdbbfa9cc",
+	"identity_secret": "f62XbJcml4r1j3NcFm0GGTtmcXw=",
+	"secret_1": "BEelQHBr74ahsgiJbGArNV62/Bs=",
+	"status": 1,
+	"steamguard_scheme": "2"
+}


### PR DESCRIPTION
- add account schema for steam app v2
- make it possible to import steam v2 accounts
- import: remove the `--sda` flag, the format should be detected automatically
- add unit tests
- make it actually work

closes #305 