### PR TITLE
setup: add support for different link confirmation types, and verify that the authenticator was actually set up

### DIFF
--- a/src/accountmanager.rs
+++ b/src/accountmanager.rs
@@ -196,14 +196,14 @@ impl AccountManager {
 		Ok(())
 	}
 
-	pub fn remove_account(&mut self, account_name: String) {
+	pub fn remove_account(&mut self, account_name: &String) {
 		let index = self
 			.manifest
 			.entries
 			.iter()
-			.position(|a| a.account_name == account_name)
+			.position(|a| &a.account_name == account_name)
 			.unwrap();
-		self.accounts.remove(&account_name);
+		self.accounts.remove(account_name);
 		self.manifest.entries.remove(index);
 	}
 

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -94,7 +94,7 @@ where
 		}
 
 		for account_name in successful {
-			manager.remove_account(account_name);
+			manager.remove_account(&account_name);
 		}
 
 		manager.save()?;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -34,6 +34,16 @@ pub(crate) fn prompt() -> String {
 	line
 }
 
+pub(crate) fn prompt_non_empty(prompt_text: impl AsRef<str>) -> String {
+	loop {
+		eprint!("{}", prompt_text.as_ref());
+		let input = prompt();
+		if !input.is_empty() {
+			return input;
+		}
+	}
+}
+
 /// Prompt the user for a single character response. Useful for asking yes or no questions.
 ///
 /// `chars` should be all lowercase characters, with at most 1 uppercase character. The uppercase character is the default answer if no answer is provided.


### PR DESCRIPTION
fixes #345
