### PR TITLE
PKGBUILD: disabled link time optimization to avoid build errors

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,6 +12,7 @@ license=('GPL3')
 makedepends=('rust' 'cargo' 'git')
 source=("git+https://github.com/dyc3/steamguard-cli.git")
 sha256sums=('SKIP')
+options=(!lto)
 
 pkgver() {
     cd "${srcdir}/${_pkgname}"


### PR DESCRIPTION
This solves build errors for me described in https://aur.archlinux.org/packages/steamguard-cli-git#comment-884235 and also reproduced in https://github.com/dyc3/steamguard-cli/actions/runs/9340294638/job/25705683797

```
error: linking with `cc` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/usr/lib64/rustlib/x86_64-unknown-linux-gnu/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" VSLANG="1033" "cc" "-m64" "/tmp/rustcWfC4he/symbols.o" "/var/ab/.cache/yay/steamguard-cli-git/src/steamguard-cli/target/release/deps/steamguard-22c99af53504a9e5.steamguard.7abfd362c63e99bf-cgu.13.rcgu.o" "-Wl,--as-needed" "-L" "/var/ab/.cache/yay/steamguard-cli-git/src/steamguard-cli/target/release/deps" "-L" "/var/ab/.cache/yay/steamguard-cli-git/src/steamguard-cli/target/release/build/ring-0dc12641040c6e8f/out" "-L" "/usr/lib64/rustlib/x86_64-unknown-linux-gnu/lib" "-Wl,-Bstatic" "/tmp/rustcWfC4he/libring-949bba2bc6e40fcb.rlib" "/usr/lib64/rustlib/x86_64-unknown-linux-gnu/lib/libcompiler_builtins-3ce9c50abe6de474.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/usr/lib64/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/var/ab/.cache/yay/steamguard-cli-git/src/steamguard-cli/target/release/deps/steamguard-22c99af53504a9e5" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-Wl,--strip-debug" "-nodefaultlibs"
  = note: /usr/sbin/ld: /var/ab/.cache/yay/steamguard-cli-git/src/steamguard-cli/target/release/deps/steamguard-22c99af53504a9e5.steamguard.7abfd362c63e99bf-cgu.13.rcgu.o: in function `ring::aead::aes_gcm::aes_gcm_seal':
          steamguard.7abfd362c63e99bf-cgu.13:(.text._ZN4ring4aead7aes_gcm12aes_gcm_seal17hdce0b4a4f2d32350E+0xa9): undefined reference to `ring_core_0_17_8_OPENSSL_ia32cap_P'
```