### PR TITLE
feat(approve): add new `approve` command to approve or deny login attempts like in the mobile app

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -9,6 +9,7 @@ use steamguard::{transport::Transport, SteamGuardAccount};
 
 use crate::AccountManager;
 
+pub mod approve;
 pub mod code;
 pub mod completions;
 pub mod confirm;
@@ -23,6 +24,7 @@ pub mod remove;
 pub mod setup;
 pub mod status;
 
+pub use approve::ApproveCommand;
 pub use code::CodeCommand;
 pub use completions::CompletionsCommand;
 pub use confirm::ConfirmCommand;
@@ -34,7 +36,7 @@ pub use import::ImportCommand;
 pub use qr::QrCommand;
 pub use qr_login::QrLoginCommand;
 pub use remove::RemoveCommand;
-pub use setup::SetupCommand;
+pub use setup::SetupCommand; // export new command
 
 /// A command that does not operate on the manifest or individual accounts.
 pub(crate) trait ConstCommand {
@@ -164,6 +166,7 @@ pub(crate) struct GlobalArgs {
 
 #[derive(Debug, Clone, Subcommand)]
 pub(crate) enum Subcommands {
+	Approve(ApproveCommand),
 	Debug(DebugCommand),
 	Completion(CompletionsCommand),
 	Setup(SetupCommand),

--- a/src/commands/approve.rs
+++ b/src/commands/approve.rs
@@ -1,0 +1,147 @@
+use crate::commands::AccountCommand;
+use crate::{commands::GlobalArgs, AccountManager};
+use clap::Parser;
+use crossterm::tty::IsTty;
+use log::*;
+use std::sync::{Arc, Mutex};
+use steamguard::approver::Challenge;
+use steamguard::protobufs::enums::ESessionPersistence;
+use steamguard::protobufs::steammessages_auth_steamclient::EAuthTokenPlatformType;
+use steamguard::transport::Transport;
+use steamguard::{LoginApprover, SteamGuardAccount};
+
+#[derive(Debug, Clone, Parser)]
+#[clap(about = "Approve or deny pending login sessions")]
+pub struct ApproveCommand {
+	#[clap(
+		short,
+		long,
+		help = "Blindly approve all pending login sessions without prompting."
+	)]
+	pub approve_all: bool,
+}
+
+impl<T> AccountCommand<T> for ApproveCommand
+where
+	T: Transport + Clone,
+{
+	fn execute(
+		&self,
+		transport: T,
+		manager: &mut AccountManager,
+		accounts: Vec<Arc<Mutex<SteamGuardAccount>>>,
+		args: &GlobalArgs,
+	) -> anyhow::Result<()> {
+		for a in accounts {
+			let mut account = a.lock().unwrap();
+
+			if !account.is_logged_in() {
+				info!("Account does not have tokens, logging in");
+				crate::do_login(transport.clone(), &mut account, args.password.clone())?;
+			}
+
+			let Some(tokens) = account.tokens.as_ref() else {
+				error!(
+					"No tokens found for {}. Can't approve login if we aren't logged in ourselves.",
+					account.account_name
+				);
+				return Err(anyhow!("No tokens found for {}", account.account_name));
+			};
+
+			let mut approver = LoginApprover::new(transport.clone(), tokens);
+
+			let sessions = approver.list_auth_sessions()?;
+			if sessions.is_empty() {
+				info!("No pending sessions to approve");
+				return Ok(());
+			}
+
+			info!("Found {} pending sessions", sessions.len());
+
+			if self.approve_all {
+				info!("Approving all pending sessions");
+				for client_id in sessions {
+					let challenge = Challenge::new(1, client_id);
+					approver.approve(
+						&account,
+						challenge,
+						ESessionPersistence::k_ESessionPersistence_Persistent,
+					)?;
+				}
+			} else if std::io::stdout().is_tty() {
+				let total = sessions.len();
+				for (session_idx, client_id) in sessions.iter().enumerate() {
+					let session = approver.get_auth_session_info(*client_id)?;
+
+					let platform_str = match session.platform_type() {
+						EAuthTokenPlatformType::k_EAuthTokenPlatformType_Unknown => "Unknown",
+						EAuthTokenPlatformType::k_EAuthTokenPlatformType_SteamClient => {
+							"Steam Client"
+						}
+						EAuthTokenPlatformType::k_EAuthTokenPlatformType_WebBrowser => {
+							"Web Browser"
+						}
+						EAuthTokenPlatformType::k_EAuthTokenPlatformType_MobileApp => "Mobile App",
+					};
+					eprintln!(
+						"[{session_idx}/{total}] Do you recognize this login attempt?
+
+	Account: {}
+	IP: {}
+	Geolocation: {}
+	City: {}, {}, {}
+	Platform: {}
+	Device Friendly Name: {}\n",
+						account.account_name,
+						session.ip(),
+						session.geoloc(),
+						session.city(),
+						session.state(),
+						session.country(),
+						platform_str,
+						session.device_friendly_name(),
+					);
+
+					let decision = crate::tui::prompt_char(
+						"What do you want to do? [A]pprove, [t]emporarily approve, [d]eny, [s]kip?",
+						"Atds",
+					);
+
+					let challenge = Challenge::new(1, *client_id);
+					match decision {
+						'a' => {
+							info!("Approving persistent session {}", client_id);
+							approver.approve(
+								&account,
+								challenge,
+								ESessionPersistence::k_ESessionPersistence_Persistent,
+							)?;
+						}
+						't' => {
+							info!("Approving ephemeral session {}", client_id);
+							approver.approve(
+								&account,
+								challenge,
+								ESessionPersistence::k_ESessionPersistence_Persistent,
+							)?;
+						}
+						'd' => {
+							info!("Denying session {}", client_id);
+							approver.deny(&account, challenge)?;
+						}
+						's' => {
+							info!("Skipping session {}", client_id);
+						}
+						_ => {
+							error!("Invalid choice");
+						}
+					}
+				}
+			} else {
+				info!("Non-interactive mode, skipping all sessions");
+			}
+		}
+		manager.save()?;
+		Ok(())
+	}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,7 @@ fn run(args: commands::Args) -> anyhow::Result<()> {
 	let globalargs = args.global;
 
 	let cmd: CommandType<WebApiTransport> = match args.sub.unwrap_or(Subcommands::Code(args.code)) {
+		Subcommands::Approve(args) => CommandType::Account(Box::new(args)),
 		Subcommands::Debug(args) => CommandType::Const(Box::new(args)),
 		Subcommands::Completion(args) => CommandType::Const(Box::new(args)),
 		Subcommands::Setup(args) => CommandType::Manifest(Box::new(args)),

--- a/steamguard/src/accountlinker.rs
+++ b/steamguard/src/accountlinker.rs
@@ -58,7 +58,7 @@ where
 		// Currently, the version value determines what `EAuthSessionGuardType` values are allowed during the login process.
 		// Version 2 allows `EAuthSessionGuardType::k_EAuthSessionGuardType_DeviceConfirmation`, where version 1 does not.
 		// However, the device confirmation auth guard does not emit a typical 2fa confirmation, so it doesn't show up when running `steamguard confirm`.
-		req.set_version(1);
+		req.set_version(2);
 
 		let resp = self
 			.client
@@ -183,6 +183,7 @@ where
 	/// As of 2025-02-07, transfering an authenticator requires a phone number to be present on the account. If there is no phone number on the account, this method will return an error.
 	pub fn transfer_start(&mut self) -> Result<(), TransferError> {
 		let req = CTwoFactor_RemoveAuthenticatorViaChallengeStart_Request::new();
+
 		let resp = self
 			.client
 			.remove_authenticator_via_challenge_start(req, self.tokens().access_token())?;
@@ -207,6 +208,7 @@ where
 		let mut req = CTwoFactor_RemoveAuthenticatorViaChallengeContinue_Request::new();
 		req.set_sms_code(sms_code.as_ref().to_owned());
 		req.set_generate_new_token(true);
+		req.set_version(2); // Version has the same meaning as it does in AddAuthenticator Request, see `link()` above.
 		let resp = self
 			.client
 			.remove_authenticator_via_challenge_continue(req, access_token)?;

--- a/steamguard/src/approver.rs
+++ b/steamguard/src/approver.rs
@@ -4,17 +4,26 @@ use reqwest::IntoUrl;
 use sha2::Sha256;
 
 use crate::{
-	protobufs::steammessages_auth_steamclient::CAuthentication_UpdateAuthSessionWithMobileConfirmation_Request,
+	protobufs::{
+		enums::ESessionPersistence,
+		steammessages_auth_steamclient::{
+			CAuthentication_GetAuthSessionInfo_Request,
+			CAuthentication_GetAuthSessionInfo_Response,
+			CAuthentication_GetAuthSessionsForAccount_Request,
+			CAuthentication_UpdateAuthSessionWithMobileConfirmation_Request,
+		},
+	},
 	steamapi::{AuthenticationClient, EResult},
 	token::{Tokens, TwoFactorSecret},
 	transport::Transport,
 	SteamGuardAccount,
 };
 
-/// QR code login approver
+/// Login approver. Lets you approve or deny login requests from other devices.
 ///
 /// This can be used to approve a login request from another device that is displaying a QR code.
-pub struct QrApprover<'a, T>
+/// This can also be used to approve any login request that allows the auth guard [`crate::protobufs::steammessages_auth_steamclient::EAuthSessionGuardType::k_EAuthSessionGuardType_DeviceConfirmation`].
+pub struct LoginApprover<'a, T>
 where
 	T: Transport,
 {
@@ -22,7 +31,7 @@ where
 	client: AuthenticationClient<T>,
 }
 
-impl<'a, T> QrApprover<'a, T>
+impl<'a, T> LoginApprover<'a, T>
 where
 	T: Transport,
 {
@@ -31,14 +40,47 @@ where
 		Self { tokens, client }
 	}
 
+	/// List all active auth sessions. Returns a list of client IDs.
+	pub fn list_auth_sessions(&self) -> Result<Vec<u64>, ApproverError> {
+		let req = CAuthentication_GetAuthSessionsForAccount_Request::new();
+		let resp = self
+			.client
+			.get_auth_sessions_for_account(req, self.tokens.access_token())?;
+
+		if resp.result != EResult::OK {
+			return Err(resp.result.into());
+		}
+
+		let data = resp.into_response_data();
+
+		Ok(data.client_ids.clone())
+	}
+
+	pub fn get_auth_session_info(
+		&self,
+		client_id: u64,
+	) -> Result<CAuthentication_GetAuthSessionInfo_Response, ApproverError> {
+		let mut req = CAuthentication_GetAuthSessionInfo_Request::new();
+		req.set_client_id(client_id);
+		let resp = self
+			.client
+			.get_auth_session_info(req, self.tokens.access_token())?;
+
+		if resp.result != EResult::OK {
+			return Err(resp.result.into());
+		}
+
+		Ok(resp.into_response_data())
+	}
+
 	/// Approve a login request from a challenge URL
 	pub fn approve(
 		&mut self,
 		account: &SteamGuardAccount,
-		challenge_url: impl IntoUrl,
-	) -> Result<(), QrApproverError> {
+		challenge: Challenge,
+		persistence: ESessionPersistence,
+	) -> Result<(), ApproverError> {
 		debug!("building signature");
-		let challenge = parse_challenge_url(challenge_url)?;
 		let signature = build_signature(&account.shared_secret, account.steam_id, &challenge);
 
 		debug!("approving login");
@@ -48,6 +90,44 @@ where
 		req.set_client_id(challenge.client_id);
 		req.set_signature(signature.to_vec());
 		req.set_confirm(true);
+		req.set_persistence(persistence);
+
+		let resp = self
+			.client
+			.update_session_with_mobile_confirmation(req, self.tokens.access_token())?;
+
+		if resp.result != EResult::OK {
+			return Err(resp.result.into());
+		}
+
+		Ok(())
+	}
+
+	pub fn approve_from_challenge_url(
+		&mut self,
+		account: &SteamGuardAccount,
+		challenge_url: impl IntoUrl,
+		persistence: ESessionPersistence,
+	) -> Result<(), ApproverError> {
+		let challenge = parse_challenge_url(challenge_url)?;
+		self.approve(account, challenge, persistence)
+	}
+
+	pub fn deny(
+		&mut self,
+		account: &SteamGuardAccount,
+		challenge: Challenge,
+	) -> Result<(), ApproverError> {
+		debug!("building signature");
+		let signature = build_signature(&account.shared_secret, account.steam_id, &challenge);
+
+		debug!("denying login");
+		let mut req = CAuthentication_UpdateAuthSessionWithMobileConfirmation_Request::new();
+		req.set_steamid(account.steam_id);
+		req.set_version(challenge.version.into());
+		req.set_client_id(challenge.client_id);
+		req.set_signature(signature.to_vec());
+		req.set_confirm(false);
 		req.set_persistence(
 			crate::protobufs::enums::ESessionPersistence::k_ESessionPersistence_Persistent,
 		);
@@ -77,16 +157,16 @@ fn build_signature(
 	result.into_bytes().into()
 }
 
-fn parse_challenge_url(challenge_url: impl IntoUrl) -> Result<Challenge, QrApproverError> {
+pub fn parse_challenge_url(challenge_url: impl IntoUrl) -> Result<Challenge, ApproverError> {
 	let url = challenge_url
 		.into_url()
-		.map_err(|_| QrApproverError::InvalidChallengeUrl)?;
+		.map_err(|_| ApproverError::InvalidChallengeUrl)?;
 
 	let regex = regex::Regex::new(r"^https?://s.team/q/(\d+)/(\d+)(\?|$)").unwrap();
 
 	let captures = regex
 		.captures(url.as_str())
-		.ok_or(QrApproverError::InvalidChallengeUrl)?;
+		.ok_or(ApproverError::InvalidChallengeUrl)?;
 
 	let version = captures[1].parse().expect("regex should only match digits");
 	let client_id = captures[2].parse().expect("regex should only match digits");
@@ -94,19 +174,38 @@ fn parse_challenge_url(challenge_url: impl IntoUrl) -> Result<Challenge, QrAppro
 	Ok(Challenge { version, client_id })
 }
 
+/// Metadata about a login challenge.
+///
+/// The client_id is a unique identifier for this challenge. It is used to identify the challenge when approving it.
+/// The version is the version of the challenge. It should be 1.
 #[derive(Debug)]
-struct Challenge {
+pub struct Challenge {
 	version: u16,
 	client_id: u64,
 }
 
+impl Challenge {
+	/// Create a new challenge. The version should likely be 1.
+	pub fn new(version: u16, client_id: u64) -> Self {
+		Self { version, client_id }
+	}
+
+	pub fn version(&self) -> u16 {
+		self.version
+	}
+
+	pub fn client_id(&self) -> u64 {
+		self.client_id
+	}
+}
+
 #[derive(Debug, thiserror::Error)]
-pub enum QrApproverError {
+pub enum ApproverError {
 	#[error("Invalid challenge URL")]
 	InvalidChallengeUrl,
-	#[error("Steam says that this qr login challege has already been used. Try again with a new QR code.")]
+	#[error("Steam says that this login challege has already been used. Start a new session and try again.")]
 	DuplicateRequest,
-	#[error("Steam says that this qr login challege has expired. Try again with a new QR code.")]
+	#[error("Steam says that this login challege has expired. Start a new session and try again.")]
 	Expired,
 	#[error("Unauthorized")]
 	Unauthorized,
@@ -118,7 +217,7 @@ pub enum QrApproverError {
 	Unknown(anyhow::Error),
 }
 
-impl From<EResult> for QrApproverError {
+impl From<EResult> for ApproverError {
 	fn from(result: EResult) -> Self {
 		match result {
 			EResult::DuplicateRequest => Self::DuplicateRequest,
@@ -127,13 +226,13 @@ impl From<EResult> for QrApproverError {
 	}
 }
 
-impl From<anyhow::Error> for QrApproverError {
+impl From<anyhow::Error> for ApproverError {
 	fn from(err: anyhow::Error) -> Self {
 		Self::Unknown(err)
 	}
 }
 
-impl From<crate::transport::TransportError> for QrApproverError {
+impl From<crate::transport::TransportError> for ApproverError {
 	fn from(err: crate::transport::TransportError) -> Self {
 		match err {
 			crate::transport::TransportError::Unauthorized => Self::Unauthorized,

--- a/steamguard/src/lib.rs
+++ b/steamguard/src/lib.rs
@@ -1,8 +1,8 @@
 use crate::token::TwoFactorSecret;
 use accountlinker::RemoveAuthenticatorError;
 pub use accountlinker::{AccountLinkError, AccountLinker, FinalizeLinkError};
+pub use approver::{ApproverError, LoginApprover};
 pub use confirmation::*;
-pub use qrapprover::{QrApprover, QrApproverError};
 pub use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use std::io::Read;
@@ -18,10 +18,10 @@ extern crate maplit;
 
 pub mod accountlinker;
 mod api_responses;
+pub mod approver;
 mod confirmation;
 pub mod phonelinker;
 pub mod protobufs;
-mod qrapprover;
 pub mod refresher;
 mod secret_string;
 pub mod steamapi;

--- a/steamguard/src/steamapi/authentication.rs
+++ b/steamguard/src/steamapi/authentication.rs
@@ -84,6 +84,36 @@ where
 		Ok(resp)
 	}
 
+	pub fn get_auth_sessions_for_account(
+		&self,
+		req: CAuthentication_GetAuthSessionsForAccount_Request,
+		access_token: &Jwt,
+	) -> Result<ApiResponse<CAuthentication_GetAuthSessionsForAccount_Response>, TransportError> {
+		let req = ApiRequest::new(SERVICE_NAME, "GetAuthSessionsForAccount", 1u32, req)
+			.with_access_token(access_token);
+		let resp = self
+			.transport
+			.send_request::<CAuthentication_GetAuthSessionsForAccount_Request, CAuthentication_GetAuthSessionsForAccount_Response>(
+				req,
+			)?;
+		Ok(resp)
+	}
+
+	pub fn get_auth_session_info(
+		&self,
+		req: CAuthentication_GetAuthSessionInfo_Request,
+		access_token: &Jwt,
+	) -> Result<ApiResponse<CAuthentication_GetAuthSessionInfo_Response>, TransportError> {
+		let req = ApiRequest::new(SERVICE_NAME, "GetAuthSessionInfo", 1u32, req)
+			.with_access_token(access_token);
+		let resp = self
+			.transport
+			.send_request::<CAuthentication_GetAuthSessionInfo_Request, CAuthentication_GetAuthSessionInfo_Response>(
+				req,
+			)?;
+		Ok(resp)
+	}
+
 	pub fn migrate_mobile_session(
 		&mut self,
 		req: CAuthentication_MigrateMobileSession_Request,
@@ -213,6 +243,16 @@ impl BuildableRequest for CAuthentication_GetPasswordRSAPublicKey_Request {
 
 	fn requires_access_token() -> bool {
 		false
+	}
+}
+
+impl BuildableRequest for CAuthentication_GetAuthSessionsForAccount_Request {
+	fn method() -> reqwest::Method {
+		reqwest::Method::GET
+	}
+
+	fn requires_access_token() -> bool {
+		true
 	}
 }
 

--- a/steamguard/src/token.rs
+++ b/steamguard/src/token.rs
@@ -61,7 +61,8 @@ impl TwoFactorSecret {
 		String::from_utf8(code_array.to_vec()).unwrap()
 	}
 
-	pub(crate) fn expose_secret(&self) -> &[u8; 20] {
+	/// Expose the underlying secret as a byte array.
+	pub fn expose_secret(&self) -> &[u8; 20] {
 		self.0.expose_secret()
 	}
 }


### PR DESCRIPTION
closes #447
