### PR TITLE
docs: remove errant `Roaming` from Windows `%APPDATA%` path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Linux:
 - `~/maFiles/`
 
 Windows:
-- `%APPDATA%\Roaming\steamguard-cli\maFiles\`
+- `%APPDATA%\steamguard-cli\maFiles\`
 - `%USERPROFILE%\maFiles\`
 
 Your `maFiles` can be created with or imported from [Steam Desktop Authenticator][SDA]. You can create `maFiles` with steamguard-cli using the `setup` action (`steamguard setup`).


### PR DESCRIPTION
`%APPDATA%` already points to `C:\Users\<USER>\AppData\Roaming\`, `%APPDATA%\Roaming` would be  `C:\Users\<USER>\AppData\Roaming\Roaming\`