### PR TITLE
feat(tui): prompt to echo out input explicitly & add Backspace support

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -22,10 +22,21 @@ pub(crate) fn prompt() -> String {
 	while let Event::Key(KeyEvent { code, .. }) = crossterm::event::read().unwrap() {
 		match code {
 			KeyCode::Enter => {
+				eprintln!();
 				break;
 			}
 			KeyCode::Char(c) => {
 				line.push(c);
+				eprint!("{}", c);
+				let _ = stderr().flush();
+			}
+			KeyCode::Backspace => {
+				if !line.is_empty() {
+					line.pop();
+
+					eprint!("\x08 \x08");
+					let _ = stderr().flush();
+				}
 			}
 			_ => {}
 		}


### PR DESCRIPTION
This change addresses #389.

The _crossterm_ implementation on Windows places the terminal in Raw Mode, which means:

> Input will not be forwarded to screen
> Input will not be processed on enter press
> Special keys like backspace and CTRL+C will not be processed by terminal driver

To address these issues, I've made the echoing explicit to ensure user input is visible, and also added support for Backspace, as it didn't work previously.

I've tested this on Windows and confirmed it's working correctly, with the username and confirmation displayed as expected, and the password remaining hidden. I haven't tested on Linux yet, but it should be working just fine; please kindly verify it first.

![test](https://github.com/user-attachments/assets/df44bf86-b9e0-4a2f-a44d-5281eb58005a)
![20250627204729](https://github.com/user-attachments/assets/35ab6d0b-6761-4056-92da-eb4ad6ff87ea)

