### PR TITLE
Update import command in quickstart documentation

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,7 +48,7 @@ If you have used [Steam Desktop Authenticator][SDA] before, you can use your exi
 It's also possible to import a single maFile from Steam Desktop Authenticator and add it to your existing manifest.
 
 ```bash
-steamguard import --sda <path to maFile>
+steamguard import --files <path to maFile>
 ```
 
 [SDA]: https://github.com/Jessecar96/SteamDesktopAuthenticator


### PR DESCRIPTION
updated import parameter to match https://github.com/dyc3/steamguard-cli/blob/master/src/commands/import.rs

running the `import` command with `--sda` does not work:
```
error: unexpected argument '--sda' found

Usage: steamguard import [OPTIONS]

For more information, try '--help'.
```
we can see in [import.rs](https://github.com/dyc3/steamguard-cli/blob/master/src/commands/import.rs) the correct flag is `--files`
