### PR TITLE
feat(cli): allow --version output with other command flags

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -80,7 +80,7 @@ where
 }
 
 #[derive(Debug, Clone, Parser)]
-#[clap(name="steamguard-cli", bin_name="steamguard", author, version, about = "Generate Steam 2FA codes and confirm Steam trades from the command line.", long_about = None)]
+#[clap(name="steamguard-cli", bin_name="steamguard", author, version, disable_version_flag = true, about = "Generate Steam 2FA codes and confirm Steam trades from the command line.", long_about = None)]
 pub(crate) struct Args {
 	#[clap(flatten)]
 	pub global: GlobalArgs,
@@ -133,6 +133,14 @@ pub(crate) struct GlobalArgs {
 	pub passkey: Option<SecretString>,
 	#[clap(short, long, value_enum, default_value_t=Verbosity::Info, help = "Set the log level. Be warned, trace is capable of printing sensitive data.")]
 	pub verbosity: Verbosity,
+
+	#[clap(
+		short = 'V',
+		long = "version",
+		action = clap::ArgAction::SetTrue,
+		help = "Print version information. Can be combined with other flags/commands."
+	)]
+	pub show_version: bool,
 
 	#[cfg(feature = "updater")]
 	#[clap(

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,15 @@ fn main() {
 }
 
 fn run(args: commands::Args) -> anyhow::Result<()> {
+	let print_version_only = args.global.show_version && args.sub.is_none() && !args.code.offline;
 	let globalargs = args.global;
+
+	if globalargs.show_version {
+		println!("{} {}", env!("CARGO_BIN_NAME"), env!("CARGO_PKG_VERSION"));
+		if print_version_only {
+			return Ok(());
+		}
+	}
 
 	let cmd: CommandType<WebApiTransport> = match args.sub.unwrap_or(Subcommands::Code(args.code)) {
 		Subcommands::Approve(args) => CommandType::Account(Box::new(args)),


### PR DESCRIPTION
## Summary
- disable clap's auto-exit version flag and add an explicit global `-V/--version` boolean
- print `steamguard <version>` at startup when `--version` is provided
- keep backward-friendly behavior for `steamguard --version` (prints version and exits), while allowing combined usage like `steamguard -V -u <user> trade`

## Testing
- Not run locally: `cargo` is not installed in this runtime (`cargo: command not found`), so compile/test commands could not be executed here.
- Manual validation performed by code inspection:
  - `--version` now prints version before command dispatch
  - `--version` without subcommand exits early
  - `--version` with a subcommand continues normal execution

## Related
Fixes #481
