### PR TITLE
Add flags for QR codes compatible with Bitwarden and KeePassXC

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ There are some applications that do not generate correct 2fa codes from the secr
 
 Other applications require a different format. If you use either Bitwarden or KeePassXC, you can generate a compatible QR code using their respective flags:
 ```bash
-steamguard qr --bitwarden # Bitwarden compatible format
-steamguard qr --keepassxc # KeePassXC compatible format
+steamguard qr --format bitwarden # Bitwarden compatible format
+steamguard qr --format keepassxc # KeePassXC compatible format
 ```
 
 # Contributing

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ There are some applications that do not generate correct 2fa codes from the secr
 - Google Authenticator
 - Authy
 
+Other applications require a different format. If you use either Bitwarden or KeePassXC, you can generate a compatible QR code using their respective flags:
+```bash
+steamguard qr --bitwarden # Bitwarden compatible format
+steamguard qr --keepassxc # KeePassXC compatible format
+```
+
 # Contributing
 
 By contributing code to this project, you give me and any future maintainers a non-exclusive transferable license to use that code for this project, including permission to modify, redistribute, and relicense it.

--- a/src/commands/qr.rs
+++ b/src/commands/qr.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, Mutex};
 
+use base64::Engine;
 use log::*;
 use qrcode::QrCode;
 use secrecy::ExposeSecret;
@@ -7,6 +8,17 @@ use secrecy::ExposeSecret;
 use crate::AccountManager;
 
 use super::*;
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+#[clap(rename_all = "lowercase")]
+pub(crate) enum QrFormat {
+	/// The default Steam otpauth URI
+	Steam,
+	/// Bitwarden-compatible format: steam://<secret>
+	Bitwarden,
+	/// KeePassXC-compatible otpauth URI with period, digits, and encoder parameters
+	KeePassXc,
+}
 
 #[derive(Debug, Clone, Parser)]
 #[clap(about = "Generate QR codes. This *will* print sensitive data to stdout.")]
@@ -17,21 +29,9 @@ pub struct QrCommand {
 	)]
 	pub ascii: bool,
 
-	/// Generate QR codes in Bitwarden-compatible format (steam://<secret>).
-	#[clap(
-		long,
-		conflicts_with = "keepassxc",
-		help = "Generate QR codes compatible with Bitwarden (steam://<secret>)"
-	)]
-	pub bitwarden: bool,
-
-	/// Generate QR codes in KeePassXC-compatible format (includes period, digits, encoder parameters).
-	#[clap(
-		long,
-		conflicts_with = "bitwarden",
-		help = "Generate QR codes compatible with KeePassXC (otpauth URI with period=30&digits=5&encoder=steam)"
-	)]
-	pub keepassxc: bool,
+	/// Output format for the QR code content.
+	#[clap(long, value_enum, default_value = "steam")]
+	pub format: QrFormat,
 }
 
 impl<T> AccountCommand<T> for QrCommand
@@ -51,21 +51,16 @@ where
 
 		for account in accounts {
 			let account = account.lock().unwrap();
-			let uri_raw = account.uri.expose_secret();
+			let secret_b64 = base64::engine::general_purpose::STANDARD
+				.encode(account.shared_secret.expose_secret());
 
-			let qr_content: String = if self.bitwarden {
-				let secret = parse_secret_from_uri(uri_raw)
-					.context("failed to parse secret from URI")?;
-				format!("steam://{}", secret)
-			} else if self.keepassxc {
-				let (secret, username) = parse_secret_and_username(uri_raw)
-					.context("failed to parse URI")?;
-				format!(
+			let qr_content: String = match self.format {
+				QrFormat::Steam => account.uri.expose_secret().to_owned(),
+				QrFormat::Bitwarden => format!("steam://{}", secret_b64),
+				QrFormat::KeePassXc => format!(
 					"otpauth://totp/Steam:{}?secret={}&period=30&digits=5&issuer=Steam&encoder=steam",
-					username, secret
-				)
-			} else {
-				uri_raw.to_owned()
+					account.account_name, secret_b64
+				),
 			};
 
 			let qr = QrCode::new(qr_content.as_bytes())
@@ -90,26 +85,4 @@ where
 		}
 		Ok(())
 	}
-}
-
-/// Extract the `secret` query parameter from an `otpauth://totp/...` URI.
-fn parse_secret_from_uri(uri: &str) -> Option<&str> {
-	let query = uri.split('?').nth(1)?;
-	for pair in query.split('&') {
-		if let Some(val) = pair.strip_prefix("secret=") {
-			return Some(val);
-		}
-	}
-	None
-}
-
-/// Extract the `secret` and `username` from an `otpauth://totp/Steam:username?...` URI.
-fn parse_secret_and_username(uri: &str) -> Option<(String, String)> {
-	let uri = uri.strip_prefix("otpauth://totp/")?;
-	let (path, query) = uri.split_once('?')?;
-	let username = path.split_once(':').map(|(_, u)| u).unwrap_or(path).to_string();
-	let secret = query
-		.split('&')
-		.find_map(|pair| pair.strip_prefix("secret="))?;
-	Some((secret.to_string(), username))
 }

--- a/src/commands/qr.rs
+++ b/src/commands/qr.rs
@@ -57,10 +57,13 @@ where
 			let qr_content: String = match self.format {
 				QrFormat::Steam => account.uri.expose_secret().to_owned(),
 				QrFormat::Bitwarden => format!("steam://{}", secret_b64),
-				QrFormat::KeePassXc => format!(
-					"otpauth://totp/Steam:{}?secret={}&period=30&digits=5&issuer=Steam&encoder=steam",
-					account.account_name, secret_b64
-				),
+				QrFormat::KeePassXc => {
+					let username = percent_encode_username(&account.account_name);
+					format!(
+						"otpauth://totp/Steam:{}?secret={}&period=30&digits=5&issuer=Steam&encoder=steam",
+						username, secret_b64
+					)
+				}
 			};
 
 			let qr = QrCode::new(qr_content.as_bytes())
@@ -84,5 +87,56 @@ where
 			println!("{}", qr_string);
 		}
 		Ok(())
+	}
+}
+
+/// Percent-encode characters that are unsafe in a URI path component.
+///
+/// Only encodes characters that would structurally break a URI (delimiters,
+/// the percent escape character itself, and non-ASCII bytes). Safe unreserved
+/// characters (RFC 3986) pass through unchanged.
+fn percent_encode_username(s: &str) -> String {
+	let mut out = String::with_capacity(s.len());
+	for b in s.bytes() {
+		match b {
+			b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+				out.push(b as char);
+			}
+			_ => {
+				out.push('%');
+				out.push_str(&format!("{:02X}", b));
+			}
+		}
+	}
+	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn percent_encode_username_passes_through_safe_chars() {
+		assert_eq!(percent_encode_username("abc123_-"), "abc123_-");
+	}
+
+	#[test]
+	fn percent_encode_username_encodes_reserved_chars() {
+		assert_eq!(percent_encode_username("user?name"), "user%3Fname");
+		assert_eq!(percent_encode_username("user&name"), "user%26name");
+		assert_eq!(percent_encode_username("user#name"), "user%23name");
+		assert_eq!(percent_encode_username("user:name"), "user%3Aname");
+		assert_eq!(percent_encode_username("user/name"), "user%2Fname");
+		assert_eq!(percent_encode_username("user%20name"), "user%2520name");
+	}
+
+	#[test]
+	fn percent_encode_username_encodes_space() {
+		assert_eq!(percent_encode_username("user name"), "user%20name");
+	}
+
+	#[test]
+	fn percent_encode_username_encodes_non_ascii() {
+		assert_eq!(percent_encode_username("usér"), "us%C3%A9r");
 	}
 }

--- a/src/commands/qr.rs
+++ b/src/commands/qr.rs
@@ -16,6 +16,22 @@ pub struct QrCommand {
 		help = "Force using ASCII chars to generate QR codes. Useful for terminals that don't support unicode."
 	)]
 	pub ascii: bool,
+
+	/// Generate QR codes in Bitwarden-compatible format (steam://<secret>).
+	#[clap(
+		long,
+		conflicts_with = "keepassxc",
+		help = "Generate QR codes compatible with Bitwarden (steam://<secret>)"
+	)]
+	pub bitwarden: bool,
+
+	/// Generate QR codes in KeePassXC-compatible format (includes period, digits, encoder parameters).
+	#[clap(
+		long,
+		conflicts_with = "bitwarden",
+		help = "Generate QR codes compatible with KeePassXC (otpauth URI with period=30&digits=5&encoder=steam)"
+	)]
+	pub keepassxc: bool,
 }
 
 impl<T> AccountCommand<T> for QrCommand
@@ -35,7 +51,24 @@ where
 
 		for account in accounts {
 			let account = account.lock().unwrap();
-			let qr = QrCode::new(account.uri.expose_secret())
+			let uri_raw = account.uri.expose_secret();
+
+			let qr_content: String = if self.bitwarden {
+				let secret = parse_secret_from_uri(uri_raw)
+					.context("failed to parse secret from URI")?;
+				format!("steam://{}", secret)
+			} else if self.keepassxc {
+				let (secret, username) = parse_secret_and_username(uri_raw)
+					.context("failed to parse URI")?;
+				format!(
+					"otpauth://totp/Steam:{}?secret={}&period=30&digits=5&issuer=Steam&encoder=steam",
+					username, secret
+				)
+			} else {
+				uri_raw.to_owned()
+			};
+
+			let qr = QrCode::new(qr_content.as_bytes())
 				.context(format!("generating qr code for {}", account.account_name))?;
 
 			info!("Printing QR code for {}", account.account_name);
@@ -57,4 +90,26 @@ where
 		}
 		Ok(())
 	}
+}
+
+/// Extract the `secret` query parameter from an `otpauth://totp/...` URI.
+fn parse_secret_from_uri(uri: &str) -> Option<&str> {
+	let query = uri.split('?').nth(1)?;
+	for pair in query.split('&') {
+		if let Some(val) = pair.strip_prefix("secret=") {
+			return Some(val);
+		}
+	}
+	None
+}
+
+/// Extract the `secret` and `username` from an `otpauth://totp/Steam:username?...` URI.
+fn parse_secret_and_username(uri: &str) -> Option<(String, String)> {
+	let uri = uri.strip_prefix("otpauth://totp/")?;
+	let (path, query) = uri.split_once('?')?;
+	let username = path.split_once(':').map(|(_, u)| u).unwrap_or(path).to_string();
+	let secret = query
+		.split('&')
+		.find_map(|pair| pair.strip_prefix("secret="))?;
+	Some((secret.to_string(), username))
 }


### PR DESCRIPTION
i feared my preferred password manager Bitwarden was also part of the "some applications that do not generate correct 2fa codes from the secret" as described in the readme. Luckily I found #468 and saw you said you wouldn't oppose a PR to implement flags for the qr command to more cleanly enable the export of secrets for those 2 password managers so I decided to make one! Let me know if I need to change anything, I will try to update accordingly.
Closes #468