### PR TITLE
fix: confirmation rate-limit errors

### DIFF
--- a/steamguard/src/confirmation.rs
+++ b/steamguard/src/confirmation.rs
@@ -239,6 +239,7 @@ where
 				"application/x-www-form-urlencoded; charset=UTF-8",
 			)
 			.header("Origin", "https://steamcommunity.com")
+			// Steam Community eventually returns HTTP 429 without this browser-style header.
 			.header("Accept-Language", "en-US,en;q=0.9")
 			.body(query_params)
 			.send()?;

--- a/steamguard/src/confirmation.rs
+++ b/steamguard/src/confirmation.rs
@@ -239,6 +239,7 @@ where
 				"application/x-www-form-urlencoded; charset=UTF-8",
 			)
 			.header("Origin", "https://steamcommunity.com")
+			.header("Accept-Language", "en-US,en;q=0.9")
 			.body(query_params)
 			.send()?;
 


### PR DESCRIPTION
Add the browser-style `Accept-Language` header to bulk confirmation requests. Steam Community now appears to require this header on non-GET requests and otherwise eventually responds with HTTP 429.

Closes #509

## Testing

- `cargo test -p steamguard` (22 passed)